### PR TITLE
simple fix: make the to string method on ecs instnaces more succinct …

### DIFF
--- a/libraries/alicloud_ecs_instances.rb
+++ b/libraries/alicloud_ecs_instances.rb
@@ -133,6 +133,6 @@ class AliCloudECSInstances < AliCloudResourceBase
   end
 
   def to_s
-    "ECS Instances #{table}"
+    'AliCloud ECS Instances (All)'
   end
 end


### PR DESCRIPTION
…with it's output

Signed-off-by: srb3 <sbrown@chef.io>

### Description

A change to the ecs instances `to_s` method

### Issues Resolved
previously instances output was dumping the filter table structure:
```
     ✔  ECS Instances [{:description=>"", :memory=>8192, :instance_charge_type=>"PostPaid", :cpu=>2, :os_name=>"Ubuntu  18.04 64位", :instance_network_type=>"vpc", :inner_ip_address=>[], :expired_time=>"2099-12-3
1T15:59Z", :image_id=>"ubuntu_18_04_64_20G_alibase_20190624.vhd", :eip_address=>{"AllocationId"=>"", "IpAddress"=>"", "InternetChargeType"=>""}, :host_name=>"iZd7o3el3sp9lrbgpgju5jZ", :vlan_id=>"", :status=>"Runn
ing", :metadata_options=>{"HttpTokens"=>"", "HttpEndpoint"=>""}, :instance_id=>"i-d7o3el3sp9lrbgpgju5j", :stopped_mode=>"Not-applicable", :cpu_options=>{"ThreadsPerCore"=>2, "Numa"=>"ON", "CoreCount"=>1}, :start_
time=>"2020-08-27T07:44Z", :deletion_protection=>false, :security_group_ids=>{"SecurityGroupId"=>["sg-d7o0ab990gkmobed14fo"]}, :vpc_attributes=>{"PrivateIpAddress"=>{"IpAddress"=>["10.0.1.39"]}, "VpcId"=>"vpc-d7o
0p139ylv4g94y5ptp0", "VSwitchId"=>"vsw-d7oy7q8i91ynerf45521k", "NatIpAddress"=>""}, :internet_charge_type=>"PayByTraffic", :instance_name=>"instance-bpbpztrgwovblldypksqacpbv", :deployment_set_id=>"", :internet_m
ax_bandwidth_out=>10, :serial_number=>"3873d2b5-2d24-4730-b4ae-bfe81e8b61dd", :os_type=>"linux", :creation_time=>"2020-08-27T07:44Z", :auto_release_time=>"", :instance_type_family=>"ecs.g6", :dedicated_instance_a
ttribute=>{"Tenancy"=>"", "Affinity"=>""}, :public_ip_address=>{"IpAddress"=>["8.208.77.2"]}, :gpu_spec=>"", :network_interfaces=>{"NetworkInterface"=>[{"PrimaryIpAddress"=>"10.0.1.39", "NetworkInterfaceId"=>"eni
-d7o3el3sp9lrbgpcrv9q", "MacAddress"=>"00:16:3e:01:17:8d"}]}, :spot_price_limit=>0.0, :device_available=>true, :sale_cycle=>"", :instance_type=>"ecs.g6.large", :os_names_en=>"Ubuntu  18.04 64 bit", :spot_strategy
=>"NoSpot"}] is expected to exist   

```

This PR changes it to:

```
 ✔  alicloud-instances-1.0: Ensure Alicloud ECS Instances Class has correct attributes
     ✔  AliCloud ECS Instances (All) is expected to exist
     ✔  AliCloud ECS Instances (All) entries.count is expected to be >= 1
```

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ x] All Integration Tests pass
- [ ] All Unit Tests pass
- [ x] `rake lint` passes
- [ x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
