### PR TITLE
ram related resources change

### DIFF
--- a/libraries/alicloud_ram_access_key.rb
+++ b/libraries/alicloud_ram_access_key.rb
@@ -17,14 +17,14 @@ class AliCloudAccessKey < AliCloudResourceBase
   def initialize(opts = {})
     opts = { access_key_id: opts } if opts.is_a?(String)
     super(opts)
-    validate_parameters(required: %i(access_key_id))
+    validate_parameters(required: %i(access_key_id), allow: %i(user_name))
 
     catch_alicloud_errors do
+      params = { "RegionId": opts[:region] }
+      params[:UserName] = opts[:user_name] if opts.key?(:user_name)
       @keys = @alicloud.ram_client.request(
         action: 'ListAccessKeys',
-            params: {
-              "RegionId": opts[:region],
-            },
+            params: params,
             opts: {
               method: 'POST',
             },

--- a/libraries/alicloud_ram_access_keys.rb
+++ b/libraries/alicloud_ram_access_keys.rb
@@ -22,13 +22,15 @@ class AliCloudAccessKeys < AliCloudResourceBase
              .install_filter_methods_on_resource(self, :table)
 
   def initialize(opts = {})
+    opts = { user_name: opts } if opts.is_a?(String)
     super(opts)
+    validate_parameters(allow: %i(user_name))
     catch_alicloud_errors do
+      params = { "RegionId": opts[:region] }
+      params[:UserName] = opts[:user_name] if opts.key?(:user_name)
       @keys = @alicloud.ram_client.request(
         action: 'ListAccessKeys',
-          params: {
-            "RegionId": opts[:region],
-          },
+          params: params,
           opts: {
             method: 'POST',
           },

--- a/libraries/alicloud_ram_user_mfa.rb
+++ b/libraries/alicloud_ram_user_mfa.rb
@@ -13,12 +13,13 @@ class AliCloudRamUserMFA < AliCloudResourceBase
   end
   '
 
-  attr_reader :serial_number
+  attr_reader :serial_number, :user_name
 
   def initialize(opts = {})
     opts = { user_name: opts } if opts.is_a?(String)
     super(opts)
     validate_parameters(required: %i(user_name))
+    @user_name = opts[:user_name]
 
     catch_alicloud_errors do
       @resp = @alicloud.ram_client.request(
@@ -47,6 +48,6 @@ class AliCloudRamUserMFA < AliCloudResourceBase
   end
 
   def to_s
-    "MFA for #{serial_number}"
+    "MFA #{@serial_number} for #{@user_name}"
   end
 end

--- a/test/integration/build/aliCloud.tf
+++ b/test/integration/build/aliCloud.tf
@@ -396,6 +396,10 @@ resource "alicloud_ram_user" "user" {
   email        = var.alicloud_ram_user_email
 }
 
+resource "alicloud_ram_access_key" "ak" {
+  user_name = alicloud_ram_user.user.name
+}
+
 ########### ECS Instances ##################
 
 resource "alicloud_kms_key" "ecs" {

--- a/test/integration/build/outputs.tf
+++ b/test/integration/build/outputs.tf
@@ -58,3 +58,6 @@ output "alicloud_bucket_versioning_name" {
 output "alicloud_instance_id" {
   value = alicloud_instance.instance.id
 }
+output "alicloud_ram_access_key_id" {
+  value = alicloud_ram_access_key.ak.id
+}

--- a/test/integration/verify/controls/alicloud_ram_access_key.rb
+++ b/test/integration/verify/controls/alicloud_ram_access_key.rb
@@ -1,3 +1,6 @@
+alicloud_ram_user_name = input(:alicloud_ram_user_name, value: '', description: 'AliCloud RAM User\'s name.')
+alicloud_ram_access_key_id = input(:alicloud_ram_access_key_id, value: '', description: 'AliCloud Access Key ID')
+
 title 'Test AliCloud access key'
 
 control 'alicloud-access-key-1.0' do
@@ -12,5 +15,9 @@ control 'alicloud-access-key-1.0' do
 
     describe alicloud_access_key('not-exists') do
         it { should_not exist }
+    end
+
+    describe alicloud_access_key(access_key_id: alicloud_ram_access_key_id, user_name: alicloud_ram_user_name) do
+        it { should exist }
     end
 end

--- a/test/integration/verify/controls/alicloud_ram_access_keys.rb
+++ b/test/integration/verify/controls/alicloud_ram_access_keys.rb
@@ -1,3 +1,6 @@
+alicloud_ram_user_name = input(:alicloud_ram_user_name, value: '', description: 'AliCloud RAM User\'s name.')
+alicloud_ram_access_key_id = input(:alicloud_ram_access_key_id, value: '', description: 'AliCloud Access Key ID')
+
 title 'Test AliCloud access keys group'
 
 control 'alicloud-access-keys-1.0' do
@@ -7,5 +10,10 @@ control 'alicloud-access-keys-1.0' do
     describe alicloud_access_keys do
         it { should exist }
         its('access_key_ids') { should include ENV['ALICLOUD_ACCESS_KEY'] }  # gets key of running user
+    end
+
+    describe alicloud_access_keys(alicloud_ram_user_name) do
+        it { should exist }
+        its('access_key_ids') { should include alicloud_ram_access_key_id }  # gets key of other user
     end
 end


### PR DESCRIPTION
Signed-off-by: Thomas Qian <thomas.qian@sap.com>

### Description

Changes in alicloud_ram_access_key and alicloud_ram_access_keys is to support getting access key(s) not only for the running user but also for user specified in resource parameter.
Also slight change is made in alicloud_ram_user_mfa.to_s, so that inspec output can show which user the MFA setting is related to.

### Issues Resolved

N/A

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [x] New functionality includes integration tests/controls
- [x] New Terraform resources  `alicloud_ram_access_key`
- [N/A] Documentation provided or updated for resources 
- [x] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
