### PR TITLE
Update Gemfile to point train-alicloud to rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "bundle"
 gem "inspec-bin"
 gem "aliyunsdkcore"
 gem "aliyun-sdk", "~> 0.8.0"
-gem "train-alicloud", git: "git@github.com/inspec/train-alicloud.git"
+gem "train-alicloud", "~> 0.0.2"
 
 group :development do
   gem "pry"

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "bundle"
 gem "inspec-bin"
 gem "aliyunsdkcore"
 gem "aliyun-sdk", "~> 0.8.0"
-gem "train-alicloud", git: "git@github.com/inspec/train-alicloud"
+gem "train-alicloud", git: "git@github.com/inspec/train-alicloud.git"
 
 group :development do
   gem "pry"

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "bundle"
 gem "inspec-bin"
 gem "aliyunsdkcore"
 gem "aliyun-sdk", "~> 0.8.0"
-gem "train-alicloud", git: "git@github.com:chef-customers/train-alicloud.git"
+gem "train-alicloud", git: "git@github.com/inspec/train-alicloud"
 
 group :development do
   gem "pry"


### PR DESCRIPTION
### Description

Changing the url for the train-alicloud plugin to public repo.

### Issues Resolved

#45 

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [x] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
