### PR TITLE
remove checks for ruby-2.5

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,14 +1,6 @@
 ---
 steps:
 
-- label: run-tests-ruby-2.5
-  command:
-    - /workdir/.expeditor/buildkite/verify.sh
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.5-stretch
-
 - label: run-tests-ruby-2.6
   command:
     - /workdir/.expeditor/buildkite/verify.sh


### PR DESCRIPTION
support for ruby 2.5 ended by core chef utils!

Signed-off-by: Sathish <sbabu@progress.com>

### Description
Core Chef Utils does not support ruby 2.5 any more hence removing checks on the same!

### Issues Resolved

Failed PR checks

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [X] All Integration Tests pass
- [X] All Unit Tests pass
- [ ] `rake lint` passes
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
