### PR TITLE
Add alicloud_ram_policy + alicloud_ram_policies resources, plus bug fixes & cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 * **[Project State](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md): Prototyping**
 
-This InSpec resource pack uses the AliCloud SDK v0 and provides the required resources to write tests for resources in AliCloud.
+This InSpec resource pack uses the AliCloud SDK v0.8.0 and provides the required resources to write tests for resources in AliCloud.
 
 ## Prerequisites
 
@@ -22,7 +22,7 @@ Set your AliCloud credentials in an `.envrc` file or export them in your shell. 
 ```
 
 ## Resources
-This resouce pack allows the testing of the following AliCloud resources. If a resource you wish to test is not listed, please feel free to open an [Issue](https://github.com/chef-customers/inspec-alicloud/issues). As an open source project, we also welcome public contributions via [Pull Request](https://github.com/chef-customers/inspec-alicloud/pulls).
+This resource pack allows the testing of the following AliCloud resources. If a resource you wish to test is not listed, please feel free to open an [Issue](https://github.com/chef-customers/inspec-alicloud/issues). As an open source project, we also welcome public contributions via [Pull Request](https://github.com/chef-customers/inspec-alicloud/pulls).
 
 - [alicloud_actiontrail_trail](libraries/alicloud_actiontrail_trail.rb)
 - [alicloud_actiontrail_trails](libraries/alicloud_actiontrail_trails.rb)
@@ -31,11 +31,14 @@ This resouce pack allows the testing of the following AliCloud resources. If a r
 - [alicloud_disks](libraries/alicloud_disks.rb)
 - [alicloud_ecs_instance](libraries/alicloud_ecs_instance.rb)
 - [alicloud_ecs_instances](libraries/alicloud_ecs_instances.rb)
+- [alicloud_ims_sso](libraries/alicloud_ims_sso.rb)
 - [alicloud_oss_bucket](libraries/alicloud_oss_bucket.rb)
 - [alicloud_oss_buckets](libraries/alicloud_oss_buckets.rb)
 - [alicloud_ram_access_key](libraries/alicloud_ram_access_key.rb)
 - [alicloud_ram_access_keys](libraries/alicloud_ram_access_keys.rb)
 - [alicloud_ram_password_policy](libraries/alicloud_ram_password_policy.rb)
+- [alicloud_ram_policy](libraries/alicloud_ram_policy.rb)
+- [alicloud_ram_policies](libraries/alicloud_ram_policies.rb)
 - [alicloud_ram_user](libraries/alicloud_ram_user.rb)
 - [alicloud_ram_user_mfa](libraries/alicloud_ram_user_mfa.rb)
 - [alicloud_ram_users](libraries/alicloud_ram_users.rb)
@@ -55,7 +58,7 @@ This resouce pack allows the testing of the following AliCloud resources. If a r
 
 #### Train and InSpec Dependencies
 
-InSpec AliCloud depends on version 0 of the AliCloud SDK that is provided via [Train AliCloud](https://github.com/chef-customers/train-alicloud). InSpec does not ship with Train AliCloud so this is explicitly listed in the Gemfile here.
+InSpec AliCloud depends on version 0.0.4 of the AliCloud SDK that is provided via [Train AliCloud](https://github.com/chef-customers/train-alicloud). InSpec does not ship with Train AliCloud so this is explicitly listed in the Gemfile here.
 
 ### Running the unit and integration tests
 

--- a/docs/resources/alicloud_ram_policies.md
+++ b/docs/resources/alicloud_ram_policies.md
@@ -1,0 +1,85 @@
+---
+title: About the alicloud_ram_policies Resource
+platform: alicloud
+---
+
+# alicloud\_ram\_policies
+
+Use the `alicloud_ram_policies` InSpec audit resource to test properties of a collection of Alicloud RAM Policies.
+
+## Syntax
+
+An `alicloud_ram_policies` resource returns a collection of RAM Policies and allows testing of that collection.
+
+    describe alicloud_ram_policies do
+      its('policy_names') { should include('test-policy-1') }
+    end
+
+#### Parameters
+
+##### type _(optional)_
+
+This resource allows filtering by PolicyType.
+To list only Alicloud managed policies, set `type` to `System`. To list only the customer managed policies in your Alicloud account, set `type` to `Custom`. If type is not supplied, both types of policies are returned.
+
+##### only\_attached _(optional)_
+
+This resource allows filtering by attached entities.
+When `only_attached` is `true`, the returned list contains only the policies that are attached to a RAM user, group, or role. When `only_attached` is `false`, or when the parameter is not included, all policies of the specified type(s) (`System` and/or `Custom`) are returned, whether they are attached to any RAM users, groups, or roles, or not.
+
+##### region _(optional)_
+
+The Alicloud Region ID - see the [Alicloud documentation on Regions and Zones](https://www.alibabacloud.com/help/doc-detail/40654.htm).  
+If provided, it must be passed as `region: 'value'`.  
+If not provided, the `ALICLOUD_REGION` environment variable will be used.
+
+See also the [Alicloud documentation on RAM Policy](https://partners-intl.aliyun.com/help/doc-detail/93732.htm).
+
+## Properties
+
+|Property              | Description|
+| ---                  | --- |
+|policy\_names         | The policy names. |
+|default\_versions     | The 'default\_version' value of each policy. |
+|attachment\_counts    | The count of attached entities for each policy. |
+|attached\_groups      | The list of group names of the groups attached to each policy. |
+|attached\_roles       | The list of role names of the roles attached to each policy. |
+|attached\_users       | The list of usernames of the users attached to each policy. |
+|entries               | Provides access to the raw results of the query, which can be treated as an array of hashes. |
+
+## Examples
+
+##### Ensure a policy exists
+    describe alicloud_ram_policies do
+      its('policy_names') { should include('test-policy-1') }
+    end
+
+##### Allow at most 100 RAM Policies on the account
+    describe alicloud_ram_policies do
+      its('entries.count') { should be <= 100}
+    end
+
+## Matchers
+
+For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+
+#### exist
+
+The control will pass if the describe returns at least one result.
+
+Use `should_not` to test the entity should not exist.
+
+    describe alicloud_ram_policies.where( <property>: <value>) do
+      it { should exist }
+    end
+
+    describe alicloud_ram_policies.where( <property>: <value>) do
+      it { should_not exist }
+    end
+
+## Alicloud Permissions
+
+Your Principal will need the `ram:ListPolicies` and `ram:ListEntitiesForPolicy` actions with Effect set to Allow.
+
+See the [Alibaba Cloud Resource Access Management documentation](https://www.alibabacloud.com/help/doc-detail/57445.htm?spm=a2c63.p38356.b99.12.51ef1b28W18VZd) and
+[documentation on authentication to RAM APIs](https://partners-intl.aliyun.com/help/doc-detail/102666.htm).

--- a/docs/resources/alicloud_ram_policy.md
+++ b/docs/resources/alicloud_ram_policy.md
@@ -1,0 +1,220 @@
+---
+title: About the alicloud_ram_policy Resource
+platform: alicloud
+---
+
+# alicloud\_ram\_policy
+
+Use the `alicloud_ram_policy` InSpec audit resource to test properties of a single managed Alicloud RAM Policy.
+
+## Syntax
+
+An `alicloud_ram_policy` resource block identifies a policy by policy name.
+
+    # Find a policy by name
+    describe alicloud_ram_policy(policy_name: 'AliyunSupportFullAccess') do
+      it { should exist }
+    end
+
+#### Parameters
+
+This resource requires the `policy_name` to be provided.
+
+##### policy\_name _(required)_
+
+The Policy Name which uniquely identifies the Policy.  
+It can be passed as a string if it is the only parameter, or using hash syntax, `policy_name: 'value'`.
+
+##### type _(optional)_
+
+The type of policy: 'System' or 'Custom'.  
+If provided, it must be passed as `type: 'value'` .  
+If not provided, both types of policies will be searched.
+
+##### region _(optional)_
+
+The Alicloud Region ID - see the [Alicloud documentation on Regions and Zones](https://www.alibabacloud.com/help/doc-detail/40654.htm).  
+If provided, it must be passed as `region: 'value'`.  
+If not provided, the `ALICLOUD_REGION` environment variable will be used.
+
+See also the [Alicloud documentation on RAM Policy](https://partners-intl.aliyun.com/help/doc-detail/93732.htm).
+
+## Properties
+
+|Property               | Description|
+| ---                   | --- |
+|policy_name            | The name of the specified policy. |
+|attachment\_count      | The count of attached entities for the specified policy. |
+|attached\_groups       | The list of group names of the groups attached to the policy. |
+|attached\_group\_count | The count of attached groups for the specified policy. |
+|attached\_roles        | The list of ARNs of the roles attached to the policy. |
+|attached\_role\_count  | The count of attached roles for the specified policy. |
+|attached\_users        | The list of usernames of the users attached to the policy. |
+|attached\_user\_count  | The count of attached users for the specified policy. |
+|default\_version       | The default version value of the specified policy. |
+|policy\_document       | Returns the default version of the policy document after decoding as a Ruby hash. This hash contains the policy statements and is useful for performing checks that cannot be expressed using higher-level matchers like `have_statement`. |
+|statement\_count       | Returns the number of statements present in the `policy`. |
+
+## Examples
+
+##### Test that a policy does exist
+    describe alicloud_ram_policy(policy_name: 'AliyunSupportFullAccess', type: 'System') do
+      it { should exist }
+    end
+
+##### Test that a policy is attached to at least one entity
+    describe alicloud_ram_policy(policy_name: 'AliyunSupportFullAccess') do
+      it { should be_attached }
+    end
+
+##### Examine the policy statements
+    describe alicloud_ram_policy(policy_name: 'my-policy', type: 'Custom') do
+      # Verify that there is at least one statement allowing access to OSS
+      it { should have_statement(Action: 'oss:PutObject', Effect: 'allow') }
+
+      # have_statement does not expand wildcards. If you want to verify
+      # they are absent, an explicit check is required.
+      it { should_not have_statement(Action: 'oss:*') }
+
+      # You can also check NotAction
+      it { should_not have_statement(NotAction: 'ram:*') }
+
+      # Check number of statements in policy
+      its('statement_count') { should be > 1 }
+    end
+
+##### Examine attached users, groups and roles
+
+    describe alicloud_ram_policy(policy_name: 'my-policy') do
+      it { should be_attached_to_user('user-1') }
+      its{'attached_users') { should include 'user-1' }
+
+      it { should be_attached_to_group('group-1') }
+      its{'attached_groups') { should include 'group-1' }
+
+      it { should be_attached_to_role('acs:ram::12345:role/role-1') }
+      its{'attached_roles') { should include 'acs:ram::12345:role/role-1' }
+
+      its('attached_user_count') { should eq 5 }
+      its('attached_group_count') { should eq 1 }
+      its('attached_role_count') { should be > 0 }
+      its('attachment_count') { should be eq 7 }
+    end
+
+## Matchers
+
+This InSpec audit resource has the following special matchers. For a full list of available matchers, please visit our [Universal Matchers page](https://www.inspec.io/docs/reference/matchers/).
+
+#### exist
+
+The control will pass if the describe returns at least one result.
+
+Use `should_not` to test the entity should not exist.
+
+      it { should exist }
+
+      it { should_not exist }
+
+#### be\_attached
+
+The test will pass if the identified policy is attached to at least one RAM user, group, or role.
+
+    describe alicloud_ram_policy(policy_name: 'AliyunSupportFullAccess') do
+      it { should be_attached }
+    end
+
+#### be\_attached\_to\_group(GROUPNAME)
+
+The test will pass if the identified policy is attached to the specified group.
+
+    describe alicloud_ram_policy(policy_name: 'AliyunSupportFullAccess') do
+      it { should be_attached_to_group(GROUPNAME) }
+    end
+
+#### be\_attached\_to\_user(USERNAME)
+
+The test will pass if the identified policy is attached to the specified user.
+
+    describe alicloud_ram_policy(policy_name: 'AliyunSupportFullAccess') do
+      it { should be_attached_to_user(USERNAME) }
+    end
+
+#### be\_attached\_to\_role(ROLEARN)
+
+The test will pass if the identified policy is attached to the specified role ARN.
+
+    describe alicloud_ram_policy(policy_name: 'AliyunSupportFullAccess') do
+      it { should be_attached_to_role(ROLEARN) }
+    end
+
+#### have\_statement
+
+Examines the list of statements contained in the policy and passes if at least one of the statements matches. This matcher does _not_ interpret the policy in a request authorization context, as Alicloud does when a request processed. Rather, `have_statement` examines the literal contents of the RAM policy, and reports on what is present (or absent, when used with `should_not`).
+
+`have_statement` accepts the following criteria to search for matching statements. If any statement matches all the criteria, the test is successful.  All keys in criteria may be used as Titlecase or lowercase, string or symbol. Values must be in the expected case.
+
+* `Action` - Expresses the requested operation. Acceptable literal values are any Alicloud operation name, including the '*' wildcard character. `Action` may also use a list of Alicloud operation names.
+* `Effect` - Expresses if the operation is permitted. Acceptable values are 'Deny' and 'Allow'.
+* `Sid` - A user-provided string identifier for the statement.
+* `Resource` - Expresses the operation's target. Acceptable values are ARNs, including the '*' wildcard. `Resource` may also use a list of ARN values.
+
+Please note the following about the behavior of `have_statement`:
+* `Action`, `Sid`, and `Resource` allow using a regular expression as the search critera instead of a string literal.
+* It does not support wildcard expansion; to check for a wildcard value, check for it explicitly. For example, if the policy includes a statement with `"Action": "oss:*"` and the test checks for `Action: "oss:PutObject"`, the test _will not match_. You must write an additional test checking for the wildcard case.
+* It supports searching list values. For example, if a statement contains a list of 3 resources, and a `have_statement` test specifes _one_ of those resources, it will match.
+* `Action` and `Resource` allow using a list of string literals or regular expressions in a test, in which case _all_ must match on the _same_ statement for the test to match. Order is ignored.
+* It does not support the Principal or Condition policy elements.
+
+Examples:
+
+    # Verify there is no full-admin statement
+    describe alicloud_ram_policy(policy_name: 'kryptonite') do
+      it { should_not have_statement('Effect' => 'Allow', 'Resource' => '*', 'Action' => '*')}
+    end
+
+    # Symbols and lowercase also allowed as criteria
+    describe alicloud_ram_policy(policy_name: 'kryptonite') do
+      # All 4 the same
+      it { should_not have_statement('Effect' => 'Allow', 'Resource' => '*', 'Action' => '*')}
+      it { should_not have_statement('effect' => 'Allow', 'resource' => '*', 'action' => '*')}
+      it { should_not have_statement(Effect: 'Allow', Resource: '*', Action: '*')}
+      it { should_not have_statement(effect: 'Allow', resource: '*', action: '*')}
+    end
+
+    # Verify bob is allowed to manage things on OSS buckets that start with bobs-stuff
+    describe alicloud_ram_policy(policy_name: 'bob-is-a-packrat') do
+      it { should have_statement(Effect: 'Allow',
+                                 # Using the Alicloud wildcard - this must match exactly
+                                 Resource: 'acs:oss:::bobs-stuff*',
+                                 # Specify a list of actions - all must match, no others, order isn't important
+                                 Action: ['oss:PutObject', 'oss:GetObject', 'oss:DeleteObject'])}
+
+      # Bob would make new buckets constantly if we let him.
+      it { should_not have_statement(Effect: 'Allow', Action: 'oss:CreateBucket')}
+      it { should_not have_statement(Effect: 'Allow', Action: 'oss:*')}
+      it { should_not have_statement(Effect: 'Allow', Action: '*')}
+
+      # An alternative to checking for wildcards is to specify the
+      # statements you expect, then restrict statement count
+      its('statement_count') { should cmp 1 }
+    end
+
+    # Use regular expressions to examine the policy
+    describe alicloud_ram_policy(policy_name: 'regex-demo') do
+      # Check to see if anything mentions RDS at all.
+      # This catches `rds:CreateDBinstance` and `rds:*`, but would not catch '*'.
+      it { should_not have_statement(Action: /^rds:.+$/)}
+
+      # This policy should refer to both sally and kim's OSS buckets.
+      # This will only match if there is a statement that refers to both resources.
+      it { should have_statement(Resource: [/acs:oss.+:sally/, /acs:oss.+:kim/]) }
+      # The following also matches on a statement mentioning only one of them
+      it { should have_statement(Resource: /acs:oss.+:(sally|kim)/) }
+    end
+
+## Alicloud Permissions
+
+Your Principal will need the `ram:GetPolicy` and `ram:ListEntitiesForPolicy` actions with Effect set to Allow.
+
+See the [Alibaba Cloud Resource Access Management documentation](https://www.alibabacloud.com/help/doc-detail/57445.htm?spm=a2c63.p38356.b99.12.51ef1b28W18VZd) and
+[documentation on authentication to RAM APIs](https://partners-intl.aliyun.com/help/doc-detail/102666.htm).

--- a/libraries/alicloud_actiontrail_trail.rb
+++ b/libraries/alicloud_actiontrail_trail.rb
@@ -15,8 +15,9 @@ class AliCloudActionTrailTrail < AliCloudResourceBase
 
   def initialize(opts = {})
     opts = { trail_name: opts } if opts.is_a?(String)
+    @opts = opt
     super(opts)
-    validate_parameters(required: [:trail_name])
+    validate_parameters(required: %i{trail_name region})
 
     @trail_name = opts[:trail_name]
     catch_alicloud_errors do
@@ -28,10 +29,7 @@ class AliCloudActionTrailTrail < AliCloudResourceBase
         }
       )["TrailList"]
 
-      if resp.empty?
-        @trail_name = "empty response"
-        return
-      end
+      return if resp.empty?
 
       @trail = resp.first
       @oss_bucket_name = @trail["OssBucketName"]

--- a/libraries/alicloud_actiontrail_trails.rb
+++ b/libraries/alicloud_actiontrail_trails.rb
@@ -14,9 +14,11 @@ class AliCloudActionTrailTrails < AliCloudResourceBase
   attr_reader :table
 
   def initialize(opts = {})
+    @opts = opts
     # Call the parent class constructor
     super(opts)
-    validate_parameters
+    validate_parameters(required: %i{region})
+
     @table = fetch_data
   end
 

--- a/libraries/alicloud_backend.rb
+++ b/libraries/alicloud_backend.rb
@@ -155,14 +155,14 @@ class AliCloudResourceBase < Inspec.resource(1)
     @opts = opts
     # ensure we have a AliCloud connection, resources can choose which of the clients to instantiate
     client_args = {}
-    if opts.is_a?(Hash)
+    if @opts.is_a?(Hash)
       # below allows each resource to optionally and conveniently set a region
       client_args[:region] = opts[:region] if opts[:region]
       # below allows each resource to optionally and conveniently set an endpoint
       client_args[:endpoint] = opts[:endpoint] if opts[:endpoint]
+      # Default region to ALICLOUD_REGION env var - needed in the resource requests for most resources
+      @opts[:region] ||= ENV["ALICLOUD_REGION"]
     end
-    # Default region to ALICLOUD_REGION env var - needed in the resource requests for most resources
-    @opts[:region] ||= ENV["ALICLOUD_REGION"]
     @alicloud = AliCloudConnection.new(client_args)
   end
 
@@ -173,6 +173,7 @@ class AliCloudResourceBase < Inspec.resource(1)
   def validate_parameters(allow: [], required: nil, require_any_of: nil)
     if required
       raise ArgumentError, "Expected required parameters as Array of Symbols, got #{required}" unless required.is_a?(Array) && required.all? { |r| r.is_a?(Symbol) }
+      raise ArgumentError, "#{@__resource_name__}: region must be provided" if required.include?(:region) && (!@opts.is_a?(Hash) || (@opts[:region].nil? || @opts[:region] == ""))
       raise ArgumentError, "#{@__resource_name__}: `#{required}` must be provided" unless @opts.is_a?(Hash) && required.all? { |req| @opts.key?(req) && !@opts[req].nil? && @opts[req] != "" }
 
       allow += required
@@ -185,11 +186,14 @@ class AliCloudResourceBase < Inspec.resource(1)
       allow += require_any_of
     end
 
-    allow += %i{region endpoint}
+    allow += %i{region} unless allow.include?(:region)
+    allow += %i{endpoint} unless allow.include?(:endpoint)
+    @opts.delete(:region) if @opts.is_a?(Hash) && @opts[:region].nil?
+
     raise ArgumentError, "Scalar arguments not supported" unless defined?(@opts.keys)
     raise ArgumentError, "Unexpected arguments found" unless @opts.keys.all? { |a| allow.include?(a) }
     raise ArgumentError, "Provided parameter should not be empty" unless @opts.values.all? do |a|
-      return true if a.class == Integer
+      return true if a.instance_of?(Integer) || a.instance_of?(TrueClass) || a.instance_of?(FalseClass)
 
       !a.empty?
     end
@@ -202,12 +206,14 @@ class AliCloudResourceBase < Inspec.resource(1)
   end
 
   # Intercept AliCloud exceptions
-  def catch_alicloud_errors
+  def catch_alicloud_errors(ignore = [])
     yield # Catch and create custom messages as needed
   rescue ArgumentError
     Inspec::Log.error "It appears that you have not set your AliCloud credentials."
     fail_resource("No AliCloud credentials available")
   rescue StandardError => e
+    ignore = [ ignore ] if ignore.is_a?(String)
+    ignore.each { |error| return nil if e.message =~ /\b#{error}\b/ }
     Inspec::Log.warn "AliCloud Service Error encountered running a control with Resource #{@__resource_name__}. " \
                       "Error message: #{e.message}. You should address this error to ensure your controls are " \
                       "behaving as expected."
@@ -225,11 +231,6 @@ class AliCloudResourceBase < Inspec.resource(1)
     else
       NullResponse.new
     end
-  end
-
-  # This is to make RuboCop happy.
-  def respond_to_missing?(*several_variants)
-    super
   end
 end
 
@@ -258,11 +259,6 @@ class NullResponse
     else
       self
     end
-  end
-
-  # This is to make RuboCop happy.
-  def respond_to_missing?(*several_variants)
-    super
   end
 
   def to_s

--- a/libraries/alicloud_disk.rb
+++ b/libraries/alicloud_disk.rb
@@ -17,8 +17,9 @@ class AliCloudDisk < AliCloudResourceBase
   def initialize(opts = {})
     opts = { disk_id: opts } if opts.is_a?(String)
     opts[:disk_id] = opts.delete(:id) if opts.key?(:id) # id is an alias for group_id
+    @opts = opts
     super(opts)
-    validate_parameters(required: %i{disk_id})
+    validate_parameters(required: %i{disk_id region})
 
     catch_alicloud_errors do
       @resp = @alicloud.ecs_client.request(
@@ -35,7 +36,6 @@ class AliCloudDisk < AliCloudResourceBase
 
     if @resp.nil?
       @encrypted = false
-      @diks_id = "empty response"
       return
     end
 
@@ -54,9 +54,7 @@ class AliCloudDisk < AliCloudResourceBase
   end
 
   def to_s
-    d = ""
-    d += "ID: #{@id} " if @id
-    d += "Name: #{@name} " if @name
-    opts.key?(:alicloud_region) ? "ECS Disk: #{d} in #{opts[:alicloud_region]}" : "ECS Disk #{d}"
+    d = @name ? " Name: #{@name}" : ""
+    @opts.key?(:region) ? "ECS Disk: ID: #{@opts[:disk_id]}#{d} in #{opts[:region]}" : "ECS Disk #{@opts[:disk_id]}#{d}"
   end
 end

--- a/libraries/alicloud_disks.rb
+++ b/libraries/alicloud_disks.rb
@@ -32,7 +32,7 @@ class AliCloudDisks < AliCloudResourceBase
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters
+    validate_parameters(required: %i{region})
     @table = fetch_data
   end
 

--- a/libraries/alicloud_ecs_instance.rb
+++ b/libraries/alicloud_ecs_instance.rb
@@ -24,8 +24,10 @@ class AliCloudECSInstance < AliCloudResourceBase
   def initialize(opts = {})
     opts = { instance_id: opts } if opts.is_a?(String)
     opts[:instance_id] = opts.delete(:id) if opts.key?(:id) # id is an alias for group_id
+    @opts = opts
     super(opts)
-    validate_parameters(required: %i{instance_id})
+    validate_parameters(required: %i{instance_id region})
+
     catch_alicloud_errors do
       @resp = @alicloud.ecs_client.request(
         action: "DescribeInstanceAttribute",
@@ -84,6 +86,6 @@ class AliCloudECSInstance < AliCloudResourceBase
   end
 
   def to_s
-    "ECS Instance #{instance_id}"
+    "ECS Instance #{@opts[:instance_id]}"
   end
 end

--- a/libraries/alicloud_ecs_instances.rb
+++ b/libraries/alicloud_ecs_instances.rb
@@ -62,7 +62,7 @@ class AliCloudECSInstances < AliCloudResourceBase
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters
+    validate_parameters(required: %i{region})
     @table = fetch_data
   end
 

--- a/libraries/alicloud_ims_sso.rb
+++ b/libraries/alicloud_ims_sso.rb
@@ -16,6 +16,8 @@ class AliCloudSsoSettings < AliCloudResourceBase
 
   def initialize(opts = {})
     super(opts)
+    validate_parameters(required: %i{region})
+
     catch_alicloud_errors do
       @resp = @alicloud.ims_client.request(
         action: "GetSamlSsoSettings",

--- a/libraries/alicloud_oss_bucket.rb
+++ b/libraries/alicloud_oss_bucket.rb
@@ -16,7 +16,7 @@ class AliCloudOssBucket < AliCloudResourceBase
   def initialize(opts = {})
     opts = { bucket_name: opts } if opts.is_a?(String)
     super(opts)
-    validate_parameters(required: [:bucket_name])
+    validate_parameters(required: %i{bucket_name region})
 
     @bucket_name = opts[:bucket_name]
 

--- a/libraries/alicloud_oss_buckets.rb
+++ b/libraries/alicloud_oss_buckets.rb
@@ -19,7 +19,7 @@ class AliCloudOssBuckets < AliCloudResourceBase
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters
+    validate_parameters(required: %i{region})
     @table = fetch_data
   end
 

--- a/libraries/alicloud_ram_access_key.rb
+++ b/libraries/alicloud_ram_access_key.rb
@@ -18,6 +18,7 @@ class AliCloudAccessKey < AliCloudResourceBase
     opts = { access_key_id: opts } if opts.is_a?(String)
     super(opts)
     validate_parameters(required: %i{access_key_id}, allow: %i{user_name})
+    @opts = opts
 
     catch_alicloud_errors do
       params = { "RegionId": opts[:region] }
@@ -48,6 +49,6 @@ class AliCloudAccessKey < AliCloudResourceBase
   end
 
   def to_s
-    "Alicloud Access Key #{access_key_id}"
+    "Alicloud Access Key #{@opts[:access_key_id]}"
   end
 end

--- a/libraries/alicloud_ram_access_keys.rb
+++ b/libraries/alicloud_ram_access_keys.rb
@@ -24,7 +24,7 @@ class AliCloudAccessKeys < AliCloudResourceBase
   def initialize(opts = {})
     opts = { user_name: opts } if opts.is_a?(String)
     super(opts)
-    validate_parameters(allow: %i{user_name})
+    validate_parameters(allow: %i{user_name}, required: %i{region})
     catch_alicloud_errors do
       params = { "RegionId": opts[:region] }
       params[:UserName] = opts[:user_name] if opts.key?(:user_name)

--- a/libraries/alicloud_ram_password_policy.rb
+++ b/libraries/alicloud_ram_password_policy.rb
@@ -23,6 +23,8 @@ class AliCloudRam < AliCloudResourceBase
 
   def initialize(opts = {})
     super(opts)
+    validate_parameters(required: %i{region})
+
     catch_alicloud_errors do
       @resp = @alicloud.ram_client.request(
         action: "GetPasswordPolicy",

--- a/libraries/alicloud_ram_policies.rb
+++ b/libraries/alicloud_ram_policies.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "alicloud_backend"
+
+class AliCloudRamPolicies < AliCloudResourceBase
+  name "alicloud_ram_policies"
+  desc "Verifies settings for a collection of AliCloud RAM Policies"
+  example '
+    describe alicloud_ram_policies do
+      it { should exist }
+    end
+  '
+
+  attr_reader :table
+
+  FilterTable.create
+    .register_column(:policy_names,      field: :policy_name)
+    .register_column(:default_versions,  field: :default_version)
+    .register_column(:attachment_counts, field: :attachment_count)
+    .register_column(:attached_groups,   field: :attached_groups)
+    .register_column(:attached_roles,    field: :attached_roles)
+    .register_column(:attached_users,    field: :attached_users)
+    .install_filter_methods_on_resource(self, :table)
+
+  def initialize(opts = {})
+    opts = { type: opts } if opts.is_a?(String)
+    super(opts)
+    validate_parameters(allow: %i{only_attached type}, required: %i{region})
+
+    @type = opts[:type]
+    opts[:type] = "System" unless opts[:type]
+    @table = fetch_data(opts)
+    return unless @type.nil?
+
+    opts[:type] = "Custom"
+    @table += fetch_data(opts)
+  end
+
+  def fetch_data(opts)
+    ram_policy_rows = []
+
+    loop do
+      response = list_policies(opts)
+      return [] if !response || response.empty?
+
+      response["Policies"]["Policy"].map do |policy|
+        unless opts[:only_attached] && policy["AttachmentCount"] == 0
+          row = { policy_name:      policy["PolicyName"],
+                  default_version:  policy["DefaultVersion"],
+                  attachment_count: policy["AttachmentCount"] }
+
+          if policy["AttachmentCount"] > 0
+            attached_entities = get_attached_entities(opts.merge({ policy_name: policy["PolicyName"] }))
+            row[:attached_groups] = attached_entities["Groups"]["Group"].map { |x| x["GroupName"] }
+            row[:attached_roles] = attached_entities["Roles"]["Role"].map { |x| x["RoleName"] }
+            row[:attached_users] = attached_entities["Users"]["User"].map { |x| x["UserName"] }
+          else
+            row[:attached_groups] = []
+            row[:attached_roles] = []
+            row[:attached_users] = []
+          end
+          ram_policy_rows += [ row ]
+        end
+      end
+
+      break unless response["IsTruncated"]
+
+      opts[:marker] = response["Marker"]
+    end
+    opts.delete(:marker)
+    ram_policy_rows
+  end
+
+  def list_policies(opts)
+    filters = { RegionId: opts[:region] }
+    filters["PolicyType"] = opts[:type]
+    filters["Marker"] = opts[:marker] if opts[:marker]
+    catch_alicloud_errors do
+      resp = @alicloud.ram_client.request(
+        action: "ListPolicies",
+        params: filters,
+        opts: {
+          method: "POST",
+        }
+      )
+      return resp
+    end
+  end
+
+  def get_attached_entities(opts)
+    filters = { RegionId: opts[:region], PolicyName: opts[:policy_name] }
+    filters["PolicyType"] = opts[:type] || "System"
+    catch_alicloud_errors do
+      resp = @alicloud.ram_client.request(
+        action: "ListEntitiesForPolicy",
+        params: filters,
+        opts: {
+          method: "POST",
+        }
+      )
+      return resp
+    end
+  end
+
+  def exists?
+    !@table.nil? && !@table.empty?
+  end
+
+  def to_s
+    "AliCloud RAM Policies (#{@type.nil? ? "All" : @type})"
+  end
+end

--- a/libraries/alicloud_ram_policy.rb
+++ b/libraries/alicloud_ram_policy.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require "alicloud_backend"
+
+class AliCloudRamPolicy < AliCloudResourceBase
+  name "alicloud_ram_policy"
+  desc "Verifies settings for a RAM Policy"
+
+  example "
+    describe alicloud_ram_policy('policy-1') do
+      it { should exist }
+      its('default_version') { should be 'v1' }
+      it { should have_statement('Effect' => 'Allow', 'Resource' => '*', 'Action' => 'ecs:Describe*') }
+      its('statement_count') { should > 1 }
+      its{'attached_users') { should include 'user-1' }
+      it { should be_attached_to_role('acs:ram::12345:role/role-1') }
+      its('attachment_count') { should be > 1 }
+    end
+  "
+
+  attr_reader :policy_name, :default_version, :policy_document,
+              :attached_users, :attached_roles, :attached_groups,
+              :attached_user_count, :attached_role_count, :attached_group_count,
+              :attachment_count
+
+  def initialize(opts = {})
+    opts = { policy_name: opts } if opts.is_a?(String)
+    super(opts)
+    validate_parameters(required: %i{policy_name region}, allow: %i{type})
+    @opts = opts
+
+    if opts[:type]
+      @resp = get_policy(opts)
+    else
+      opts[:type] = "Custom"
+      @resp = get_policy(opts)
+      if @resp.nil?
+        opts[:type] = "System"
+        @resp = get_policy(opts)
+      end
+    end
+    return if @resp.nil?
+
+    @policy = @resp["Policy"]
+    @policy_name = opts[:policy_name]
+    @default_version = @resp["Policy"]["DefaultVersion"]
+    @policy_document = @resp["DefaultPolicyVersion"]["PolicyDocument"]
+
+    @attached_users = @attached_groups = @attached_roles = @attachment_count = 0
+
+    entities = get_attached_entities(opts)
+    return if entities.nil?
+
+    @attached_users = entities["Users"]["User"].map { |x| x["UserName"] }
+    @attached_user_count = @attached_users.length
+    @attached_groups = entities["Groups"]["Group"].map { |x| x["GroupName"] }
+    @attached_group_count = @attached_groups.length
+    @attached_roles = entities["Roles"]["Role"].map { |x| x["Arn"] }
+    @attached_role_count = @attached_roles.length
+    @attachment_count = @attached_user_count + @attached_group_count + @attached_role_count
+  end
+
+  def get_policy(opts)
+    filters = { RegionId: opts[:region],
+                PolicyName: opts[:policy_name],
+                PolicyType: opts[:type] }
+    catch_alicloud_errors("EntityNotExist.Policy") do
+      resp = @alicloud.ram_client.request(
+        action: "GetPolicy",
+        params: filters,
+        opts: {
+          method: "POST",
+        }
+      )
+
+      return resp
+    end
+  end
+
+  def exists?
+    !@policy.nil?
+  end
+
+  def has_statement?(criteria = {})
+    return false unless @policy_document
+
+    document = JSON.parse(URI.decode_www_form_component(@policy_document), { symbolize_names: true })
+    statements = document[:Statement].is_a?(Array) ? document[:Statement] : [document[:Statement]].compact
+    # downcase keys to eliminate formatting issue
+    # put values in an array for standard match checking
+    criteria = criteria.each_with_object({}) { |(k, v), h| h[k.downcase.to_sym] = v.is_a?(Array) ? v : [v] }
+    return false if criteria.empty? || statements.empty?
+
+    allowed_statement_elements = %i{Action Effect Sid Resource NotAction NotResource}
+    # downcase keys to eliminate formatting issue
+    unless criteria.keys.all? { |k| allowed_statement_elements.map(&:downcase).include?(k) }
+      raise ArgumentError,
+            "Valid statement elements are #{allowed_statement_elements}, provided elements are: #{criteria.keys}"
+    end
+
+    statements.each do |statement|
+      # This is to comply with the document that allowing keys in lowercase format.
+      statement = statement.each_with_object({}) { |(k, v), acc| acc[k.downcase] = v }
+      @statement_match = false
+      criteria_match = []
+      criteria.each do |k_c, v_c|
+        criteria_match << v_c.all? do |v|
+          statement_item_in_array = statement[k_c].is_a?(Array) ? statement[k_c] : [statement[k_c]].compact
+          statement_item_in_array.include?(v)
+        end
+      end
+      @statement_match = true if criteria_match.all?(true)
+      break if criteria_match.all?(true)
+    end
+    @statement_match
+  end
+
+  def get_attached_entities(_policy_name)
+    catch_alicloud_errors("EntityNotExist.Policy") do
+      resp = @alicloud.ram_client.request(
+        action: "ListEntitiesForPolicy",
+        params: {
+          RegionId: opts[:region],
+          PolicyName: opts[:policy_name],
+          PolicyType: "Custom",
+        },
+        opts: {
+          method: "POST",
+        }
+      )
+      return resp
+    end
+  end
+
+  def statement_count
+    return false unless @policy_document
+
+    document = JSON.parse(URI.decode_www_form_component(@policy_document), { symbolize_names: true })
+    statements = document[:Statement].is_a?(Hash) ? [document[:Statement]] : document[:Statement]
+    statements.length
+  end
+
+  def attached_to_user?(username)
+    !@attached_users.nil? && @attached_users.include?(username)
+  end
+
+  def attached_to_group?(group_name)
+    !@attached_groups.nil? && @attached_groups.include?(group_name)
+  end
+
+  def attached_to_role?(role_arn)
+    !@attached_roles.nil? && @attached_roles.include?(role_arn)
+  end
+
+  def attached?
+    @attachment_count > 0
+  end
+
+  def to_s
+    "Alicloud RAM Policy #{@opts[:policy_name]}"
+  end
+end

--- a/libraries/alicloud_ram_user.rb
+++ b/libraries/alicloud_ram_user.rb
@@ -19,9 +19,9 @@ class AliCloudRamUser < AliCloudResourceBase
   def initialize(opts = {})
     opts = { user_name: opts } if opts.is_a?(String)
     super(opts)
-    validate_parameters(required: %i{user_name})
+    validate_parameters(required: %i{user_name region})
 
-    catch_alicloud_errors do
+    catch_alicloud_errors("EntityNotExist.User") do
       @resp = @alicloud.ram_client.request(
         action: "GetUser",
         params: {

--- a/libraries/alicloud_ram_user_mfa.rb
+++ b/libraries/alicloud_ram_user_mfa.rb
@@ -18,7 +18,7 @@ class AliCloudRamUserMFA < AliCloudResourceBase
   def initialize(opts = {})
     opts = { user_name: opts } if opts.is_a?(String)
     super(opts)
-    validate_parameters(required: %i{user_name})
+    validate_parameters(required: %i{user_name region})
     @user_name = opts[:user_name]
 
     catch_alicloud_errors do

--- a/libraries/alicloud_ram_users.rb
+++ b/libraries/alicloud_ram_users.rb
@@ -27,7 +27,7 @@ class AliCloudRamUsers < AliCloudResourceBase
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters
+    validate_parameters(required: %i{region})
 
     catch_alicloud_errors do
       @users = @alicloud.ram_client.request(

--- a/libraries/alicloud_rd.rb
+++ b/libraries/alicloud_rd.rb
@@ -16,6 +16,8 @@ class AliCloudResourceDirectory < AliCloudResourceBase
 
   def initialize(opts = {})
     super(opts)
+    validate_parameters(required: %i{region})
+
     catch_alicloud_errors do
       @resp = @alicloud.rm_client.request(
         action: "GetResourceDirectory",

--- a/libraries/alicloud_region.rb
+++ b/libraries/alicloud_region.rb
@@ -17,7 +17,7 @@ class AliCloudRegion < AliCloudResourceBase
     opts = { region_name: opts } if opts.is_a?(String)
 
     super(opts)
-    validate_parameters(allow: [:region_name])
+    validate_parameters(required: %i{region_name region})
 
     @region_name = opts[:region_name]
     catch_alicloud_errors do

--- a/libraries/alicloud_regions.rb
+++ b/libraries/alicloud_regions.rb
@@ -22,7 +22,7 @@ class AliCloudRegions < AliCloudResourceBase
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters
+    validate_parameters(required: %i{region})
     @table = fetch_data
   end
 

--- a/libraries/alicloud_security_groups.rb
+++ b/libraries/alicloud_security_groups.rb
@@ -29,7 +29,7 @@ class AliCloudSecurityGroups < AliCloudResourceBase
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters
+    validate_parameters(required: %i{region})
     @table = fetch_data
   end
 

--- a/libraries/alicloud_slb.rb
+++ b/libraries/alicloud_slb.rb
@@ -21,8 +21,10 @@ class AliCloudSlb < AliCloudResourceBase
     opts[:slb_id] = opts.delete(:id) if opts.key?(:id)
 
     super(opts)
-    validate_parameters(required: %i{slb_id})
-    catch_alicloud_errors do
+    validate_parameters(required: %i{slb_id region})
+    @opts = opts
+
+    catch_alicloud_errors("InvalidLoadBalancerId.NotFound") do
       @resp = @alicloud.slb_client.request(
         action: "DescribeLoadBalancerAttribute",
         params: {
@@ -113,9 +115,12 @@ class AliCloudSlb < AliCloudResourceBase
   end
 
   def to_s
-    slb = ""
-    slb += "ID: #{@load_balancer_id} " if @load_balancer_id
-    slb += "Name: #{@load_balancer_name} " if @load_balancer_name
-    opts.key?(:region) ? "Server Load Balancer: #{slb} in #{opts[:region]}" : "Server Load Balancer: #{slb}"
+    if @load_balancer_id
+      slb = " ID: #{@load_balancer_id}"
+      slb += " Name: #{@load_balancer_name}" if @load_balancer_name
+    else
+      slb = " " + @opts[:slb_id]
+    end
+    opts.key?(:region) ? "Server Load Balancer:#{slb} in #{opts[:region]}" : "Server Load Balancer:#{slb}"
   end
 end

--- a/libraries/alicloud_slb_https_listener.rb
+++ b/libraries/alicloud_slb_https_listener.rb
@@ -14,7 +14,7 @@ class AliCloudSlbHttpsListener < AliCloudResourceBase
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters(required: %i{slb_id listener_port})
+    validate_parameters(required: %i{slb_id listener_port region})
 
     catch_alicloud_errors do
       @resp = @alicloud.slb_client.request(

--- a/libraries/alicloud_slbs.rb
+++ b/libraries/alicloud_slbs.rb
@@ -41,7 +41,7 @@ class AliCloudSlbs < AliCloudResourceBase
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters
+    validate_parameters(required: %i{region})
     @table = fetch_data
   end
 

--- a/libraries/alicloud_vpc.rb
+++ b/libraries/alicloud_vpc.rb
@@ -17,7 +17,9 @@ class AliCloudVpc < AliCloudResourceBase
     opts = { vpc_id: opts } if opts.is_a?(String)
 
     super(opts)
-    validate_parameters(required: %i{vpc_id})
+    validate_parameters(required: %i{vpc_id region})
+    @opts = opts
+
     catch_alicloud_errors do
       @resp = @alicloud.vpc_client.request(
         action: "DescribeVpcAttribute",
@@ -65,6 +67,6 @@ class AliCloudVpc < AliCloudResourceBase
   end
 
   def to_s
-    "Virtual Private Cloud #{@vpc_id}"
+    "Virtual Private Cloud #{@opts[:vpc_id]}"
   end
 end

--- a/libraries/alicloud_vpcs.rb
+++ b/libraries/alicloud_vpcs.rb
@@ -35,7 +35,7 @@ class AliCloudVpcs < AliCloudResourceBase
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters
+    validate_parameters(required: %i{region})
     @table = fetch_data
   end
 

--- a/test/integration/build/outputs.tf
+++ b/test/integration/build/outputs.tf
@@ -56,8 +56,11 @@ output "alicloud_bucket_versioning_name" {
   value = alicloud_oss_bucket.bucket-versioning.0.id
 }
 output "alicloud_instance_id" {
-  value = alicloud_instance.instance.id
+  value = alicloud_instance.instance.0.id
 }
 output "alicloud_ram_access_key_id" {
-  value = alicloud_ram_access_key.ak.id
+  value = alicloud_ram_access_key.ak.0.id
+}
+output "alicloud_ram_role_arn" {
+  value = alicloud_ram_role.role.0.arn
 }

--- a/test/integration/configuration/alicloud_inspec_config.rb
+++ b/test/integration/configuration/alicloud_inspec_config.rb
@@ -19,6 +19,8 @@ module AliCloudInspecConfig
 
   # Config for terraform / inspec in the below hash
   @config = {
+      # Simple flag to disable creation of resources (useful when prototyping new ones in isolation)
+      alicloud_enable_create: 1,
       # Generic AliCloud resource parameters
       alicloud_region: @alicloud_region,
       alicloud_vpc_name: "vpc-#{add_random_string}",
@@ -80,12 +82,15 @@ module AliCloudInspecConfig
       alicloud_ecs_instance_disk_size: 20,
       alicloud_ecs_instance_disk_category: "cloud_efficiency",
       alicloud_ecs_instance_disk_encrypted: "true",
-      # Simple flag to disable creation of resources (useful when prototyping new ones in isolation)
-      alicloud_enable_create: 1,
-      alicloud_ram_user_name: "inspec-integraion-test-#{add_random_string}",
+      alicloud_ram_user_name: "inspec-integration-test-#{add_random_string}",
       alicloud_ram_user_display_name: "inspec-user",
       alicloud_ram_user_mobile: "86-18688888888",
       alicloud_ram_user_email: "user@inspec.com",
+      alicloud_ram_group_name: "test-group-#{add_random_string}",
+      alicloud_ram_role_name: "test-role-#{add_random_string}",
+      alicloud_ram_policy_name: "test-policy-#{add_random_string}",
+      alicloud_ram_attached_policy_name_1: "test-attached-policy-#{add_random_string}",
+      alicloud_ram_attached_policy_name_2: "test-attached-policy-#{add_random_string}",
   }
 
   def self.config

--- a/test/integration/verify/controls/alicloud_actiontrail_trail.rb
+++ b/test/integration/verify/controls/alicloud_actiontrail_trail.rb
@@ -18,7 +18,7 @@ control "alicloud-actiontrail-1.0" do
   describe alicloud_actiontrail_trail(trail_name: alicloud_action_trail_name) do
     it { should exist }
     its("oss_bucket_name") { should eq alicloud_action_trail_bucket_id }
-    its("delivered_logs_days_ago") { should eq 0 }
+    # its("delivered_logs_days_ago") { should eq 0 }
     its("status") { should cmp "Enable" }
     its("trail_region") { should cmp "All" }
   end

--- a/test/integration/verify/controls/alicloud_disk.rb
+++ b/test/integration/verify/controls/alicloud_disk.rb
@@ -10,7 +10,7 @@ title "Test single AliCloud Disk"
 
 control "alicloud-disk-1.0" do
   impact 1.0
-  title "Ensure AliCloud Diks has the correct properties."
+  title "Ensure AliCloud Disk has the correct properties."
 
   describe alicloud_disk(disk_id: "no-such-disk") do
     it { should_not exist }

--- a/test/integration/verify/controls/alicloud_ecs_instance.rb
+++ b/test/integration/verify/controls/alicloud_ecs_instance.rb
@@ -8,7 +8,7 @@ control "alicloud-instance-1.0" do
 
   describe alicloud_ecs_instance(instance_id: alicloud_instance_id) do  # gets region from env var
     it { should exist }
-    its("desciption") { should be_nil }
+    its("description") { should eq "" }
     its("memory") { should eq 8192 }
     its("instance_charge_type") { should eq "PostPaid" }
     its("cpu") { should eq 2 }

--- a/test/integration/verify/controls/alicloud_ram_policies.rb
+++ b/test/integration/verify/controls/alicloud_ram_policies.rb
@@ -1,0 +1,36 @@
+title "Test a collection of AliCloud RAM Policies"
+
+alicloud_ram_policy_name = attribute(:alicloud_ram_policy_name, value: "", description: "The Alicloud RAM Policy name.")
+alicloud_ram_attached_policy_name_1 = attribute(:alicloud_ram_attached_policy_name_1, value: "", description: "The Alicloud RAM Attached Policy 1 name.")
+
+control "alicloud-ram-policies-1.0" do
+
+  impact 1.0
+  title "Ensure AliCLoud RAM Policies have the correct properties."
+
+  describe alicloud_ram_policies do
+    it { should exist }
+    its("policy_names") { should include "AdministratorAccess" }
+    # Ensure multiple truncated responses are returned
+    its("entries.count") { should be > 200 }
+    its("policy_names.count") { should be > 200 }
+  end
+
+  describe alicloud_ram_policies(type: "System") do
+    it { should exist }
+    its("policy_names") { should include "AdministratorAccess" }
+    its("policy_names") { should_not include alicloud_ram_policy_name }
+  end
+
+  describe alicloud_ram_policies(type: "Custom") do
+    it { should exist }
+    its("policy_names") { should_not include "AdministratorAccess" }
+    its("policy_names") { should include alicloud_ram_policy_name }
+    its("policy_names") { should include alicloud_ram_attached_policy_name_1 }
+  end
+
+  describe alicloud_ram_policies(only_attached: true, type: "Custom") do
+    its("policy_names") { should_not include alicloud_ram_policy_name }
+    its("policy_names") { should include alicloud_ram_attached_policy_name_1 }
+  end
+end

--- a/test/integration/verify/controls/alicloud_ram_policy.rb
+++ b/test/integration/verify/controls/alicloud_ram_policy.rb
@@ -1,0 +1,70 @@
+title "Test single Alicloud RAM Policy"
+
+alicloud_ram_policy_name = attribute(:alicloud_ram_policy_name, value: "", description: "The Alicloud RAM Policy name.")
+alicloud_ram_attached_policy_name_1 = attribute(:alicloud_ram_attached_policy_name_1, value: "", description: "The Attached Alicloud RAM Policy 1 name.")
+alicloud_ram_attached_policy_name_2 = attribute(:alicloud_ram_attached_policy_name_2, value: "", description: "The Attached Alicloud RAM Policy 2 name.")
+alicloud_ram_user_name = attribute(:alicloud_ram_user_name, value: "", description: "The Alicloud RAM User name.")
+alicloud_ram_group_name = attribute(:alicloud_ram_group_name, value: "", description: "The Alicloud RAM Group name.")
+alicloud_ram_role_arn = attribute(:alicloud_ram_role_arn, value: "", description: "The Alicloud RAM Role ARN.")
+
+control "alicloud-ram-policy-1.0" do
+
+  impact 1.0
+  title "Ensure Alicloud RAM Policy has the correct properties."
+
+  describe alicloud_ram_policy(policy_name: "DoesNotExist") do
+    it { should_not exist }
+  end
+
+  describe alicloud_ram_policy("AliyunSupportFullAccess") do
+    it { should exist }
+  end
+
+  describe alicloud_ram_policy(policy_name: "AliyunSupportFullAccess", type: "Custom") do
+    it { should_not exist }
+  end
+
+  describe alicloud_ram_policy(policy_name: alicloud_ram_policy_name, type: "Custom") do
+    it { should exist }
+    it { should_not have_statement("Effect" => "Allow", "Resource" => "*", "Action" => "*") }
+    it { should have_statement("Effect" => "Allow", "Resource" => "*", "Action" => "ecs:Describe*") }
+    it { should have_statement("Effect" => "Allow", "Resource" => "acs:oss:::*", "NotAction" => "oss:DeleteBucket") }
+    its("statement_count") { should be 2 }
+    its("default_version") { should cmp "v1" }
+    it { should_not be_attached }
+    its("attached_user_count") { should eq 0 }
+    its("attached_group_count") { should eq 0 }
+    its("attached_role_count") { should eq 0 }
+    its("attachment_count") { should eq 0 }
+  end
+
+  describe alicloud_ram_policy(policy_name: alicloud_ram_policy_name, type: "System") do
+    it { should_not exist }
+  end
+
+  describe alicloud_ram_policy(policy_name: alicloud_ram_attached_policy_name_1) do
+    it { should_not be_attached_to_user("fake-user") }
+    it { should_not be_attached_to_role("fake-role") }
+    it { should be_attached_to_role(alicloud_ram_role_arn) }
+    it { should be_attached }
+    its("attached_roles") { should include alicloud_ram_role_arn }
+    its("attached_user_count") { should eq 0 }
+    its("attached_group_count") { should eq 0 }
+    its("attached_role_count") { should eq 1 }
+    its("attachment_count") { should eq 1 }
+    # Test Action in an array
+    it { should have_statement(Action: ["ecs:Describe*"]) }
+  end
+
+  describe alicloud_ram_policy(policy_name: alicloud_ram_attached_policy_name_2, type: "Custom") do
+    it { should be_attached_to_user(alicloud_ram_user_name) }
+    it { should be_attached_to_group(alicloud_ram_group_name) }
+    it { should be_attached }
+    its("attached_users") { should include alicloud_ram_user_name }
+    its("attached_user_count") { should eq 1 }
+    its("attached_groups") { should include alicloud_ram_group_name }
+    its("attached_group_count") { should eq 1 }
+    its("attached_role_count") { should eq 0 }
+    its("attachment_count") { should eq 2 }
+  end
+end

--- a/test/integration/verify/controls/alicloud_ram_user.rb
+++ b/test/integration/verify/controls/alicloud_ram_user.rb
@@ -21,4 +21,8 @@ control "alicloud-test-ram-user-1.0" do
     its("create_date") { should_not be_nil }
     its("mobile_phone") { should_not be_nil }
   end
+
+  describe alicloud_ram_user("no-such-user") do
+    it { should_not exist }
+  end
 end

--- a/test/unit/helper.rb
+++ b/test/unit/helper.rb
@@ -1,0 +1,10 @@
+gem "mocha"
+
+require "minitest/autorun"
+require "minitest/unit"
+require "minitest/pride"
+require "inspec/resource"
+require "inspec/log"
+require "mocha/minitest"
+
+Inspec::Log.logger = Logger.new(nil)

--- a/test/unit/resources/alicloud_ram_policies_test.rb
+++ b/test/unit/resources/alicloud_ram_policies_test.rb
@@ -1,0 +1,68 @@
+require "helper"
+require "alicloud_ram_policies"
+
+class AliCloudRamPoliciesConstructorTest < Minitest::Test
+  def setup
+    ENV["ALICLOUD_REGION"] = "us-east-1"
+
+    system = { "Policies" => { "Policy" => [{ "PolicyType" => "System", "Description" => "System test policies 1",
+      "AttachmentCount" => 0, "PolicyName" => "system-test-1", "DefaultVersion" => "v1" },
+      { "PolicyType" => "System", "Description" => "System test policies 2", "AttachmentCount" => 1,
+      "PolicyName" => "system-test-2", "DefaultVersion" => "v2" }, { "PolicyType" => "System",
+      "Description" => "System test policies 3", "AttachmentCount" => 0, "PolicyName" => "system-test-3",
+      "DefaultVersion" => "v1" }] }, "IsTruncated" => false }
+    custom = { "Policies" => { "Policy" => [{ "PolicyType" => "Custom", "Description" => "Test policies 1",
+      "AttachmentCount" => 1, "PolicyName" => "test-1", "DefaultVersion" => "v3" }, { "PolicyType" => "Custom",
+      "Description" => "Test policies 2", "AttachmentCount" => 0, "PolicyName" => "test-2", "DefaultVersion" => "v2" },
+      { "PolicyType" => "Custom", "Description" => "Test policies 3", "AttachmentCount" => 0, "PolicyName" => "test-3",
+      "DefaultVersion" => "v4" }] }, "IsTruncated" => false }
+
+    AliCloudRamPolicies.any_instance.stubs(:list_policies).with(type: "System", region: "us-east-1").returns(system)
+    AliCloudRamPolicies.any_instance.stubs(:list_policies).with(type: "Custom", region: "us-east-1").returns(custom)
+    AliCloudRamPolicies.any_instance.stubs(:list_policies).with(only_attached: true, region: "us-east-1", type: "System").returns(system)
+    AliCloudRamPolicies.any_instance.stubs(:list_policies).with(only_attached: true, region: "us-east-1", type: "Custom").returns(custom)
+    AliCloudRamPolicies.any_instance.stubs(:list_policies).with(type: "System", region: "eu-west-1").returns(system)
+
+    AliCloudRamPolicies.any_instance.stubs(:get_attached_entities).returns({
+     "Groups" => { "Group" => [{ "GroupName" => "group-1", "AttachDate" => "2021-01-01T00:00:00Z", "Comments" => "A comment" }] },
+     "Roles" => { "Role" => [{ "RoleName" => "role-1", "Description" => "", "Arn" => "acs:ram::12345:role/role-1", "RoleId" => "55555" }] },
+     "Users" => { "User" => [{ "UserName" => "user-1", "UserId" => "66666", "DisplayName" => "user-1" },
+                        { "UserName" => "user-2", "UserId" => "88888", "DisplayName" => "user-2" }] } })
+  end
+
+  def test_rejects_unrecognized_params
+    assert_raises(ArgumentError) { AliCloudRamPolicies.new(rubbish: 9) }
+  end
+
+  def test_accepts_no_arguments
+    policies = AliCloudRamPolicies.new
+    assert_equal %w{system-test-1 system-test-2 system-test-3 test-1 test-2 test-3}, policies.policy_names
+    assert_equal %w{v1 v2 v1 v3 v2 v4}, policies.default_versions
+    assert_equal [0, 1, 0, 1, 0, 0], policies.attachment_counts
+    assert_equal [[], ["group-1"], [], ["group-1"], [], []], policies.attached_groups
+    assert_equal [[], ["role-1"], [], ["role-1"], [], []], policies.attached_roles
+    assert_equal [[], %w{user-1 user-2}, [], %w{user-1 user-2}, [], []], policies.attached_users
+  end
+
+  def test_accepts_custom_as_string_argument
+    policies = AliCloudRamPolicies.new("Custom")
+    assert_equal %w{test-1 test-2 test-3}, policies.policy_names
+    assert_equal %w{v3 v2 v4}, policies.default_versions
+    assert_equal [["group-1"], [], []], policies.attached_groups
+    assert_equal [["role-1"], [], []], policies.attached_roles
+    assert_equal [%w{user-1 user-2}, [], []], policies.attached_users
+  end
+
+  def test_accepts_system_type_and_region
+    policies = AliCloudRamPolicies.new(type: "System", region: "eu-west-1")
+    assert_equal %w{system-test-1 system-test-2 system-test-3}, policies.policy_names
+    assert_equal %w{v1 v2 v1}, policies.default_versions
+  end
+
+  def test_only_attached
+    policies = AliCloudRamPolicies.new(only_attached: true)
+    assert_equal %w{system-test-2 test-1}, policies.policy_names
+    assert_equal %w{v2 v3}, policies.default_versions
+    assert_equal [1, 1], policies.attachment_counts
+  end
+end

--- a/test/unit/resources/alicloud_ram_policy_test.rb
+++ b/test/unit/resources/alicloud_ram_policy_test.rb
@@ -1,0 +1,92 @@
+require "helper"
+require "alicloud_ram_policy"
+
+class AliCloudRamPolicyConstructorTest < Minitest::Test
+  def setup
+    ENV["ALICLOUD_REGION"] = "us-east-1"
+
+    AliCloudRamPolicy.any_instance.stubs(:get_policy).returns({ "Policy" => { "PolicyType" => "Custom",
+      "Description" => "Test policy", "AttachmentCount" => 0, "PolicyName" => "test-policy", "DefaultVersion" => "v2" },
+      "DefaultPolicyVersion" => { "VersionId" => "v1", "IsDefaultVersion" => true,
+      "PolicyDocument" => "{\n  \"Version\": \"1\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ecs:Describe*\"\n      ],\n" +
+      "      \"Effect\": \"Allow\",\n      \"Resource\": \"*\"\n    },\n    {\n      \"NotAction\": \"oss:DeleteBucket\",\n" +
+      "      \"Effect\": \"Allow\",\n      \"Resource\": \"acs:oss:::*\"\n    }\n  ]\n}\n", "CreateDate" => "2021-01-01T00:00:00Z" } })
+
+    @policy_document = '{
+  "Version": "1",
+  "Statement": [
+    {
+      "Action": [
+        "ecs:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "NotAction": "oss:DeleteBucket",
+      "Effect": "Allow",
+      "Resource": "acs:oss:::*"
+    }
+  ]
+}
+'
+    AliCloudRamPolicy.any_instance.stubs(:get_attached_entities).returns({
+     "Groups" => { "Group" => [{ "GroupName" => "group-1", "Comments" => "A comment" }] },
+     "Roles" => { "Role" => [{ "RoleName" => "role-1", "Description" => "", "Arn" => "acs:ram::12345:role/role-1", "RoleId" => "55555" }] },
+     "Users" => { "User" => [{ "UserName" => "user-1", "UserId" => "66666", "DisplayName" => "user-1" },
+                             { "UserName" => "user-2", "UserId" => "88888", "DisplayName" => "user-2" }] } })
+  end
+
+  def test_empty_params_not_ok
+    assert_raises(ArgumentError) { AliCloudRamPolicy.new }
+  end
+
+  def test_rejects_unrecognized_params
+    assert_raises(ArgumentError) { AliCloudRamPolicy.new(rubbish: 9) }
+  end
+
+  def test_accepts_string_argument
+    policy = AliCloudRamPolicy.new("atestpolicy")
+    assert_equal "atestpolicy", policy.policy_name
+  end
+
+  def test_accepts_key_value_argument_and_resource_works
+    policy = AliCloudRamPolicy.new(policy_name: "atestpolicy")
+    assert_equal "atestpolicy", policy.policy_name
+    assert_equal "v2", policy.default_version
+    assert_equal @policy_document, policy.policy_document
+    assert_equal true, policy.has_statement?({ Effect: "Allow", Resource: "acs:oss:::*", NotAction: "oss:DeleteBucket" })
+    assert_equal true, policy.has_statement?({ 'Effect': "Allow", 'Resource': "acs:oss:::*", 'NotAction': "oss:DeleteBucket" })
+    assert_equal true, policy.has_statement?({ 'effect': "Allow", 'resource': "acs:oss:::*", 'notaction': "oss:DeleteBucket" })
+    assert_equal 2, policy.statement_count
+    assert_equal true, policy.attached_to_user?("user-2")
+    assert_equal 2, policy.attached_user_count
+    assert_equal true, policy.attached_to_group?("group-1")
+    assert_equal 1, policy.attached_group_count
+    assert_equal true, policy.attached_to_role?("acs:ram::12345:role/role-1")
+    assert_equal 1, policy.attached_role_count
+    assert_equal 4, policy.attachment_count
+    assert_equal true, policy.attached?
+  end
+
+  def test_accepts_policy_name_and_region
+    policy = AliCloudRamPolicy.new(policy_name: "atestpolicy", region: "eu-west-1")
+    assert_equal "atestpolicy", policy.policy_name
+  end
+
+  def test_accepts_policy_name_and_custom_type
+    policy = AliCloudRamPolicy.new(policy_name: "atestpolicy", type: "Custom")
+    assert_equal "v2", policy.default_version
+  end
+
+  def test_accepts_policy_name_and_system_type
+    policy = AliCloudRamPolicy.new(policy_name: "atestpolicy", type: "System")
+    assert_equal @policy_document, policy.policy_document
+  end
+
+  def test_not_attached
+    AliCloudRamPolicy.any_instance.stubs(:get_attached_entities).returns(nil)
+    policy = AliCloudRamPolicy.new(policy_name: "atestpolicy")
+    assert_equal 0, policy.attachment_count
+  end
+end


### PR DESCRIPTION
### Description

This PR adds two new resources, alicloud_ram_policy and alicloud_ram_policies, plus some bug fixes and cleanup.

### Issues Resolved

Customer request to be able to test whether policies are attached to users, and to be able to check privileges granted by policies.

Other issues discovered and resolved:

1) Fixes to libraries/alicloud_backend.rb:
- fixed a bug where @opts[region] was attempted to be set, where @opts was a string
- various bug fixes and improvements around validation of parameters, including a better error message if region is unset, making sure there is no error if region is unset but a particular resource doesn't need region, and allowing resource parameters to have boolean values
- added the ability to `catch_alicloud_errors` to ignore one or more StandardErrors passed in as string arguments. These are errors like disk doesn't exist; they really aren't errors, if InSpec is querying to find out if they exist, and it is confusing to see error messages.

2) Fixes to other resources:
- added region to required parameters in the `validate_parameters` call, where region is needed; this cleans up most of the ruby errors when ALICLOUD_REGION is not set; the user instead sees an error message about region needing to be provided
- changed the `to_s` method for some resources so it displays the actual resource the user is attempting to scan when it does not exist, rather than an empty string which is not useful; also removed extra whitespace in the to_s method for some resources
- updated resources' `catch_alicloud_errors` calls to ignore errors that are not really errors, where integration tests were raising errors for these
   
 3) Fixes to aliCloud.tf:
 - added `count = var.alicloud_enable_create` to most resources that did not have it, and adjusted references to those resources where needed -- this makes it easier to test parts of the code in isolation when developing new resources
- deleted some redundant resources, related to a deprecation
  
4) Fixes to InSpec integration tests:
- disabled the `delivered_logs_days_ago` test in alicloud_actiontrail_trail.rb. This is not a good test as there is nothing to trigger logs to be delivered so it always fails.
- fixed a typo in a test in alicloud_ecs_instance.rb

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [x] New functionality includes integration tests/controls
- [x] New Terraform resources
- [x] Documentation provided or updated for resources 
- [x] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
