### PR TITLE
Add proper API endpoint formats for AliCloud VPN service

### DIFF
--- a/libraries/alicloud_backend.rb
+++ b/libraries/alicloud_backend.rb
@@ -33,7 +33,12 @@ class AliCloudConnection
     endpoint ||= if %w{sts ram resourcemanager ims rds}.include?(api)
                    "https://#{api}.aliyuncs.com"
                  else
-                   "https://#{api}.#{region}.aliyuncs.com"
+                    # AliCloud VPN endpoints vary between regions, so the following accounts for that variability
+                    if api == 'vpn' && %w{cn-qingdao cn-beijing cn-beijing cn-shanghai cn-shenzhen cn-hongkong ap-southeast-1 us-west-1 us-east-1 cn-shanghai-finance-1 cn-shenzhen-finance-1 cn-north-2-gov-1}.include(region)
+                      "https://#{api}.aliyuncs.com"
+                    else
+                      "https://#{api}.#{region}.aliyuncs.com"
+                    end  
                  end
     client = RPCClient.new(
       access_key_id:     ENV["ALICLOUD_ACCESS_KEY"],

--- a/libraries/alicloud_backend.rb
+++ b/libraries/alicloud_backend.rb
@@ -33,12 +33,12 @@ class AliCloudConnection
     endpoint ||= if %w{sts ram resourcemanager ims rds}.include?(api)
                    "https://#{api}.aliyuncs.com"
                  else
-                    # AliCloud VPN endpoints vary between regions, so the following accounts for that variability
-                    if api == 'vpn' && %w{cn-qingdao cn-beijing cn-beijing cn-shanghai cn-shenzhen cn-hongkong ap-southeast-1 us-west-1 us-east-1 cn-shanghai-finance-1 cn-shenzhen-finance-1 cn-north-2-gov-1}.include(region)
-                      "https://#{api}.aliyuncs.com"
-                    else
-                      "https://#{api}.#{region}.aliyuncs.com"
-                    end  
+                   # AliCloud VPN endpoints vary between regions, so the following accounts for that variability
+                   if api == "vpn" && %w{cn-qingdao cn-beijing cn-beijing cn-shanghai cn-shenzhen cn-hongkong ap-southeast-1 us-west-1 us-east-1 cn-shanghai-finance-1 cn-shenzhen-finance-1 cn-north-2-gov-1}.include(region)
+                     "https://#{api}.aliyuncs.com"
+                   else
+                     "https://#{api}.#{region}.aliyuncs.com"
+                   end
                  end
     client = RPCClient.new(
       access_key_id:     ENV["ALICLOUD_ACCESS_KEY"],


### PR DESCRIPTION
Signed-off-by: Jon Cowie <jonlives@gmail.com>

### Description

The AliCloud VPN service does not use a universal URI format for all regions - this pull request addresses those regional differences and makes sure that we use the right URIs for each region.

### Issues Resolved

As above

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [ ] All Unit Tests pass
- [ ] `rake lint` passes
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
