### PR TITLE
Fix instance IDs to preserve JSON array format

### DIFF
--- a/libraries/alicloud_ecs_instance.rb
+++ b/libraries/alicloud_ecs_instance.rb
@@ -76,7 +76,7 @@ class AliCloudECSInstance < AliCloudResourceBase
         action: "DescribeInstances",
         params: {
           'RegionId': opts[:region],
-          'InstanceIds': [opts[:instance_id]].to_json,
+          'InstanceIds': "[\"#{opts[:instance_id]}\"]",
         },
         opts: {
           method: "POST",

--- a/libraries/alicloud_ecs_instances.rb
+++ b/libraries/alicloud_ecs_instances.rb
@@ -142,7 +142,7 @@ class AliCloudECSInstances < AliCloudResourceBase
         action: "DescribeInstanceRamRole",
         params: {
           RegionId: region,
-          InstanceIds: "[\"#{instance_id}\"]",
+          InstanceIds: "[\"#{opts[:instance_id]}\"]",
         },
         opts: {
           method: "POST",


### PR DESCRIPTION
Signed-off-by: Jon Cowie <jonlives@gmail.com>

### Description

A previous PR which used .to_json to process the ECS instance ID actually resulted in the required JSON array format not being preserved. This change fixed that formatting.

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [X] All Integration Tests pass
- [X] All Unit Tests pass
- [X] `rake lint` passes
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
