### PR TITLE
Add logic to skip rule when securitygroup specified instead of cidr mask

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,14 +1,6 @@
 ---
 steps:
 
-- label: run-tests-ruby-2.5
-  command:
-    - /workdir/.expeditor/buildkite/verify.sh
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.5-stretch
-
 - label: run-tests-ruby-2.6
   command:
     - /workdir/.expeditor/buildkite/verify.sh

--- a/libraries/alicloud_security_group.rb
+++ b/libraries/alicloud_security_group.rb
@@ -56,10 +56,10 @@ class AliCloudSecurityGroup < AliCloudResourceBase
     port = criteria[:port] unless criteria[:port].nil?
     ipv4_range = criteria[:ipv4_range]
     @inbound_rules.each do |rule|
-      
+
       # If our rule has a securitygroup ID instead of a CIDR mask as the auth object, skip it...
       next if rule["SourceCidrIp"].empty? && !rule["SourceGroupId"].empty?
-      
+
       policy = rule["Policy"]
       next unless policy == "Accept"
 

--- a/libraries/alicloud_security_group.rb
+++ b/libraries/alicloud_security_group.rb
@@ -56,6 +56,10 @@ class AliCloudSecurityGroup < AliCloudResourceBase
     port = criteria[:port] unless criteria[:port].nil?
     ipv4_range = criteria[:ipv4_range]
     @inbound_rules.each do |rule|
+      
+      # If our rule has a securitygroup ID instead of a CIDR mask as the auth object, skip it...
+      next if rule["SourceCidrIp"].empty? && !rule["SourceGroupId"].empty?
+      
       policy = rule["Policy"]
       next unless policy == "Accept"
 


### PR DESCRIPTION
Signed-off-by: Jon Cowie <jonlives@gmail.com>

### Description

Fixing an issue reported by a customer where a security group rule which in turn specifies a security group as its authorisation object will fail - this PR adds logic to skip the rule in that case but continue checking other rules in the group.

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [X] All Integration Tests pass
- [X] All Unit Tests pass
- [X `rake lint` passes
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
