### PR TITLE
Update readme, shortcodes, local build previews, and netlify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ vendor
 .bundle
 *inspec-output*
 tags
+.DS_Store

--- a/docs-chef-io/.gitignore
+++ b/docs-chef-io/.gitignore
@@ -1,0 +1,5 @@
+*.*~
+*~
+
+chef-web-docs/
+.hugo_build.lock

--- a/docs-chef-io/Makefile
+++ b/docs-chef-io/Makefile
@@ -1,0 +1,35 @@
+# we use pushd/popd here, and /bin/sh of our chefes/buildkite image is not bash
+# so we have to override the default shell here
+SHELL=bash
+
+preview_netlify: chef_web_docs
+	cp -R content/inspec/resources/* chef-web-docs/_vendor/github.com/inspec/inspec-alicloud/docs-chef-io/content/inspec/resources/
+	cp -R config.toml chef-web-docs/_vendor/github.com/inspec/inspec-alicloud/docs-chef-io/
+	pushd chef-web-docs && make assets; hugo --gc --minify --buildFuture && popd
+
+
+replace = "replacements = \'github.com/inspec/inspec-alicloud/docs-chef-io -\> ../../\'\\n\\n"
+
+serve: chef_web_docs
+	@echo -e "$(replace)" > temp.txt
+	@cat chef-web-docs/config/_default/module.toml >> temp.txt
+	@cat temp.txt > chef-web-docs/config/_default/module.toml
+	rm temp.txt
+	pushd chef-web-docs && make assets; hugo server --buildDrafts --buildFuture --noHTTPCache && popd
+
+chef_web_docs:
+	if [ -d "chef-web-docs/" ]; then \
+		pushd chef-web-docs && git reset HEAD --hard; git clean -fd; git pull --ff-only origin main; rm -rf public && popd; \
+	else \
+		git clone https://github.com/chef/chef-web-docs.git; \
+	fi
+
+clean_all:
+	rm -rf chef-web-docs
+
+clean:
+	pushd chef-web-docs && make clean_all && popd
+
+lint:
+	hugo -D
+

--- a/docs-chef-io/Makefile
+++ b/docs-chef-io/Makefile
@@ -5,7 +5,7 @@ SHELL=bash
 preview_netlify: chef_web_docs
 	cp -R content/inspec/resources/* chef-web-docs/_vendor/github.com/inspec/inspec-alicloud/docs-chef-io/content/inspec/resources/
 	cp -R config.toml chef-web-docs/_vendor/github.com/inspec/inspec-alicloud/docs-chef-io/
-	pushd chef-web-docs && make assets; hugo --gc --minify --buildFuture && popd
+	pushd chef-web-docs && make bundle; hugo --gc --minify --buildFuture && popd
 
 
 replace = "replacements = \'github.com/inspec/inspec-alicloud/docs-chef-io -\> ../../\'\\n\\n"
@@ -15,7 +15,7 @@ serve: chef_web_docs
 	@cat chef-web-docs/config/_default/module.toml >> temp.txt
 	@cat temp.txt > chef-web-docs/config/_default/module.toml
 	rm temp.txt
-	pushd chef-web-docs && make assets; hugo server --buildDrafts --buildFuture --noHTTPCache && popd
+	pushd chef-web-docs && make bundle; hugo server --buildDrafts --buildFuture --noHTTPCache && popd
 
 chef_web_docs:
 	if [ -d "chef-web-docs/" ]; then \

--- a/docs-chef-io/README.md
+++ b/docs-chef-io/README.md
@@ -1,0 +1,129 @@
+# Chef InSpec AliCloud Resource Documentation
+
+This is the home of the InSpec AliCloud resource documentation found on
+<https://docs.chef.io/inspec/resources/#alicloud>.
+
+We use [Hugo](https://gohugo.io/) to incorporate documentation from this repository into `chef/chef-web-docs` and deploy it on <https://docs.chef.io>.
+
+## Documentation Content
+
+### Resource Pages
+
+All resource pages are located in `docs-chef-io/content/inspec/resources/`.
+
+Create a new page by duplicating an old page and then update the new page with content relevant to the new resource.
+
+You can also run `hugo new -k resource inspec/resources/RESOURCE_NAME.md` to generate a new resource page from scratch.
+
+See our [style guide](https://docs.chef.io/style_index/) for suggestions on writing documentation.
+
+#### Front Matter
+
+At the top of each resource is a block of front matter, which Hugo uses to add a title to each page and locate each page in the left navigation menu in <docs.chef.io>. Below is an example of a page's front matter:
+
+```toml
++++
+title = "RESOURCE NAME resource"
+platform = "alicloud"
+gh_repo = "inspec-alicloud"
+
+[menu.inspec]
+title = "RESOURCE NAME"
+identifier = "inspec/resources/alicloud/RESOURCE NAME"
+parent = "inspec/resources/alicloud"
++++
+```
+
+`title` is the page title.
+
+`platform = alicloud` sorts each page into the correct category in the [Chef InSpec resources list page](https://docs.chef.io/inspec/resources/).
+
+`gh_repo = "inspec-alicloud"` adds an "[edit on GitHub]" link to the top of each page that links to the Markdown page in the inspec/inspec-alicloud repository.
+
+`[menu.inspec]` places the page in the Chef InSpec section of the left navigation menu in <docs.chef.io>. All the parameters following this configure the link in the left navigation menu to the page.
+
+`title` is the title of page in the Chef InSpec menu.
+
+`identifier` is the identifier for a page in the menu. It should formatted like this: `inspec/resources/alicloud/resource name`.
+
+`parent = "inspec/resources/alicloud"` is the identifier for the section of the menu that the page will be found in. This value is set in the [chef-web-docs menu config](https://github.com/chef/chef-web-docs/blob/main/config/_default/menu.toml).
+
+### Shortcodes
+
+A shortcode is a file with a block of text that can be added in multiple places in our documentation by referencing the shortcode file name.
+
+This documentation set has three shortcodes located in the `docs-chef-io/layouts/shortcodes` directory:
+
+- alibaba_access_management_docs.md
+- alibaba_authentication_ecs_api_docs.md
+- alibaba_authentication_ram_api_docs.md
+- alicloud_principal_action.md
+
+Add a shortcode to a resource page by wrapping the filename, without the `.md` file suffix, in double curly braces and percent symbols. For example: `{{% alibaba_access_management_docs %}}`.
+
+The `alicloud_principal_action.md` shortcode requires an `action` parameter, which is the action where effect must be set to allow. For example, the alicloud_disks.md resource page has:
+
+```md
+{{% alicloud_principal_action action="ecs:DescribeDisks"%}}
+```
+
+which will render the following text:
+
+> Your Principal will need the `ecs:DescribeDisks` action with `Effect` set to `Allow`.
+
+**Note:** You can add shortcodes from other repositories. For example, the `inspec_filter_table.md` and the `inspec_matchers_link.md` shortcodes are both located in the chef/chef-web-docs repository, but they can be added to this documentation set using the same method described above.
+
+## Update the InSpec Repository Module In `chef/chef-web-docs`
+
+We use [Hugo modules](https://gohugo.io/hugo-modules/) to build Chef's documentation
+from multiple repositories.
+
+Currently there is no configuration that will automatically update the AliCloud documentation on docs.chef.io. See the [chef-web-docs README](https://github.com/chef/chef-web-docs#update-hugo-modules) for information on updating a Hugo module in chef-web-docs.
+
+A member of the Docs Team can update the inspec-alicloud resource documentation at any time when new resources are ready to be added to <docs.chef.io>.
+
+## Local Development Environment
+
+We use [Hugo](https://gohugo.io/), [Go](https://golang.org/), and[NPM](https://www.npmjs.com/)
+to build the Chef Documentation website. You will need Hugo 0.93.1 or higher
+installed and running to build and view our documentation.
+
+To install Hugo, NPM, and Go on Windows and macOS:
+
+- On macOS run: `brew install hugo node go`
+- On Windows run: `choco install hugo nodejs golang -y`
+
+To install Hugo on Linux, run:
+
+- `apt install -y build-essential`
+- `snap install node --classic --channel=12`
+- `snap install hugo --channel=extended`
+
+## Preview InSpec AliCloud Resource Documentation
+
+### make serve
+
+Run `make serve` to build a local preview of the InSpec AliCloud resource documentation.
+This will clone a copy of `chef/chef-web-docs` into the `docs-chef-io` directory.
+That copy will be configured to build the InSpec AliCloud resource documentation from the `docs-chef-io` directory
+and live reload if any changes are made while the Hugo server is running.
+
+- Run `make serve`
+- go to <http://localhost:1313/inspec/resources/#alicloud>
+
+### Clean Your Local Environment
+
+Run `make clean_all` to delete the cloned copy of chef/chef-web-docs.
+
+## Documentation Feedback
+
+If you need support, contact [Chef Support](https://www.chef.io/support/).
+
+**GitHub issues**
+
+Submit an issue to the [inspec-alicloud repo](https://github.com/inspec/inspec-alicloud/issues)
+for "important" documentation bugs that may need visibility among a larger group,
+especially in situations where a documentation bug may also surface a product bug.
+
+Submit an issue to [chef-web-docs](https://github.com/chef/chef-web-docs/issues) for
+documentation feature requests and minor documentation issues.

--- a/docs-chef-io/archetypes/resource.md
+++ b/docs-chef-io/archetypes/resource.md
@@ -1,5 +1,5 @@
 +++
-title = "{{ .Name | humanize | title }} resource"
+title = "{{ .Name }} resource"
 draft = false
 gh_repo = "inspec"
 platform = "alicloud"
@@ -10,18 +10,56 @@ platform = "alicloud"
     identifier = "inspec/resources/alicloud/{{ .Name | humanize | title }}"
     parent = "inspec/resources/alicloud"
 +++
+{{/* Run `hugo new -k resource inspec/resources/RESOURCE_NAME.md` to generate a new resource page. */}}
 
-
-{{% Run `hugo new -k resource resources/RESOURCE_NAME.md` to generate a new resource page. %}}
+Use the `{{ .Name }}` Chef InSpec audit resource to test...
 
 ## Syntax
 
+```ruby
+describe {{ .Name }} do
+
+end
+```
+
 ## Parameters
+
+`PARAMETER`
+: PARAMETER DESCRIPTION
+
+`PARAMETER`
+: PARAMETER DESCRIPTION
 
 ## Properties
 
+`PROPERTY`
+: PROPERTY DESCRIPTION
+
+`PROPERTY`
+: PROPERTY DESCRIPTION
+
 ## Examples
+
+**EXAMPLE DESCRIPTION**
+
+```ruby
+describe {{ .Name }} do
+
+end
+```
+
+**EXAMPLE DESCRIPTION**
+
+```ruby
+describe {{ .Name }} do
+
+end
+```
 
 ## Matchers
 
-For a full list of available matchers, please visit our [Universal Matchers page](https://docs.chef.io/inspec/matchers/).
+{{% inspec_matchers_link %}}
+
+### AliCloud Permissions
+
+{{% alibaba_access_management_docs %}}

--- a/docs-chef-io/config.toml
+++ b/docs-chef-io/config.toml
@@ -1,0 +1,2 @@
+[params.inspec-alicloud]
+gh_path = "https://github.com/inspec/inspec-alicloud/tree/main/docs-chef-io/content/"

--- a/docs-chef-io/content/inspec/resources/alicloud_apsaradb_rds_instance.md
+++ b/docs-chef-io/content/inspec/resources/alicloud_apsaradb_rds_instance.md
@@ -25,7 +25,8 @@ describe alicloud_apsaradb_rds_instance('test-instance-id') do
 end
 ```
 
-    # Can also use hash syntax
+You can also use hash syntax:
+
 ```ruby
 describe alicloud_apsaradb_rds_instance(db_instance_id: 'test-instance-id') do
   it { should exist }
@@ -36,13 +37,13 @@ end
 
 `db_instance_id` _(required)_
 
-: This resource accepts a single parameter, the user-supplied instance identifier.   
+: This resource accepts a single parameter, the user-supplied instance identifier.
   This can be passed either as a string if it is the only parameter, or using hash syntax, `db_instance_id: 'value'`.
 
 `region` _(optional)_
 
-: The Alicloud Region ID - see the [Alicloud documentation on Regions and Zones](https://www.alibabacloud.com/help/doc-detail/40654.htm).  
-  If provided, it must be passed as `region: 'value'`.  
+: The Alicloud Region ID - see the [Alicloud documentation on Regions and Zones](https://www.alibabacloud.com/help/doc-detail/40654.htm).
+  If provided, it must be passed as `region: 'value'`.
   If not provided, the `ALICLOUD_REGION` environment variable will be used.
 
 See also the [Alicloud documentation on ApsaraDB RDS](https://www.alibabacloud.com/help/doc-detail/26092.htm).
@@ -142,7 +143,7 @@ end
 
 ## Matchers
 
-This InSpec audit resource has the following special matchers. For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+{{% inspec_matchers_link %}}
 
 ### exist
 

--- a/docs-chef-io/content/inspec/resources/alicloud_apsaradb_rds_instances.md
+++ b/docs-chef-io/content/inspec/resources/alicloud_apsaradb_rds_instances.md
@@ -126,7 +126,7 @@ end
 
 ## Matchers
 
-For a full list of available matchers, please visit our [Universal Matchers page](https://www.inspec.io/docs/reference/matchers/).
+{{% inspec_matchers_link %}}
 
 ### exist
 
@@ -148,6 +148,6 @@ end
 
 ### Alicloud Permissions
 
-Your Principal will need the `rds:DescribeDBInstances` action with Effect set to Allow.
+{{% alicloud_principal_action action="rds:DescribeDBInstances" %}}
 
 You can find documentation at [Use RAM to manage ApsaraDB for RDS permissions](https://www.alibabacloud.com/help/doc-detail/58932.htm#section-rhd-4ll-5gb).

--- a/docs-chef-io/content/inspec/resources/alicloud_disk.md
+++ b/docs-chef-io/content/inspec/resources/alicloud_disk.md
@@ -108,7 +108,7 @@ end
 
 ## Matchers
 
-This InSpec audit resource has the following special matchers. For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+{{% inspec_matchers_link %}}
 
 ### exist
 
@@ -138,7 +138,7 @@ it { should be_encrypted }
 
 ### Alicloud Permissions
 
-Your Principal will need the `ecs:DescribeDisks` action with Effect set to Allow.
+{{% alicloud_principal_action action="ecs:DescribeDisks" %}}
 
-See the [Alibaba Cloud Resource Access Management documentation](https://www.alibabacloud.com/help/doc-detail/57445.htm?spm=a2c63.p38356.b99.12.51ef1b28W18VZd) and
-[documentation on authentication rules for ECS APIs](https://partners-intl.aliyun.com/help/doc-detail/25497.htm?spm=a2c63.p38356.b99.657.7b9f3481VdEA4g).
+{{% alibaba_access_management_doc %}}
+{{% alibaba_authentication_ecs_api_doc %}}

--- a/docs-chef-io/content/inspec/resources/alicloud_disks.md
+++ b/docs-chef-io/content/inspec/resources/alicloud_disks.md
@@ -96,7 +96,7 @@ end
 
 ## Matchers
 
-For a full list of available matchers, please visit our [Universal Matchers page](https://www.inspec.io/docs/reference/matchers/).
+{{% inspec_matchers_link %}}
 
 ### exist
 
@@ -118,7 +118,7 @@ end
 
 ### Alicloud Permissions
 
-Your Principal will need the `ecs:DescribeDisks` action with Effect set to Allow.
+{{% alicloud_principal_action action="ecs:DescribeDisks" %}}
 
-See the [Alibaba Cloud Resource Access Management documentation](https://www.alibabacloud.com/help/doc-detail/57445.htm?spm=a2c63.p38356.b99.12.51ef1b28W18VZd) and
-[documentation on authentication rules for ECS APIs](https://partners-intl.aliyun.com/help/doc-detail/25497.htm?spm=a2c63.p38356.b99.657.7b9f3481VdEA4g).
+{{% alibaba_access_management_doc %}}
+{{% alibaba_authentication_ecs_api_doc %}}

--- a/docs-chef-io/content/inspec/resources/alicloud_ecs_instance.md
+++ b/docs-chef-io/content/inspec/resources/alicloud_ecs_instance.md
@@ -159,7 +159,7 @@ end
 
 ## Matchers
 
-This InSpec audit resource has the following special matchers. For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+{{% inspec_matchers_link %}}
 
 ### exist
 
@@ -179,5 +179,5 @@ it { should_not exist }
 
 Your Principal will need the `ecs:DescribeInstances`, `ecs:DescribeInstanceAttribute` and `ecs:DescribeInstanceRamRole` actions with Effect set to Allow.
 
-See the [Alibaba Cloud Resource Access Management documentation](https://www.alibabacloud.com/help/doc-detail/57445.htm?spm=a2c63.p38356.b99.12.51ef1b28W18VZd) and
-[documentation on authentication rules for ECS APIs](https://partners-intl.aliyun.com/help/doc-detail/25497.htm?spm=a2c63.p38356.b99.657.7b9f3481VdEA4g).
+{{% alibaba_access_management_doc %}}
+{{% alibaba_authentication_ecs_api_doc %}}

--- a/docs-chef-io/content/inspec/resources/alicloud_ecs_instances.md
+++ b/docs-chef-io/content/inspec/resources/alicloud_ecs_instances.md
@@ -191,7 +191,7 @@ end
 
 ## Matchers
 
-For a full list of available matchers, please visit our [Universal Matchers page](https://www.inspec.io/docs/reference/matchers/).
+{{% inspec_matchers_link %}}
 
 ### exist
 
@@ -215,5 +215,5 @@ end
 
 Your Principal will need the `ecs:DescribeInstances` and `ecs:DescribeInstanceRamRole` actions with Effect set to Allow.
 
-See the [Alibaba Cloud Resource Access Management documentation](https://www.alibabacloud.com/help/doc-detail/57445.htm?spm=a2c63.p38356.b99.12.51ef1b28W18VZd) and
-[documentation on authentication rules for ECS APIs](https://partners-intl.aliyun.com/help/doc-detail/25497.htm?spm=a2c63.p38356.b99.657.7b9f3481VdEA4g).
+{{% alibaba_access_management_doc %}}
+{{% alibaba_authentication_ecs_api_doc %}}

--- a/docs-chef-io/content/inspec/resources/alicloud_ram_policies.md
+++ b/docs-chef-io/content/inspec/resources/alicloud_ram_policies.md
@@ -109,5 +109,5 @@ end
 
 Your Principal will need the `ram:ListPolicies` and `ram:ListEntitiesForPolicy` actions with Effect set to Allow.
 
-See the [Alibaba Cloud Resource Access Management documentation](https://www.alibabacloud.com/help/doc-detail/57445.htm?spm=a2c63.p38356.b99.12.51ef1b28W18VZd) and
-[documentation on authentication to RAM APIs](https://partners-intl.aliyun.com/help/doc-detail/102666.htm).
+{{% alibaba_access_management_doc %}}
+{{% alibaba_authentication_ram_api_doc %}}

--- a/docs-chef-io/content/inspec/resources/alicloud_ram_policy.md
+++ b/docs-chef-io/content/inspec/resources/alicloud_ram_policy.md
@@ -156,7 +156,9 @@ its('attachment_count') { should be eq 7 }
 
 ## Matchers
 
-This InSpec audit resource has the following special matchers. For a full list of available matchers, please visit our [Universal Matchers page](https://www.inspec.io/docs/reference/matchers/).
+This InSpec audit resource has the following special matchers.
+
+{{% inspec_matchers_link %}}
 
 ### exist
 
@@ -295,5 +297,5 @@ it { should have_statement(Resource: /acs:oss.+:(sally|kim)/) }
 
 Your Principal will need the `ram:GetPolicy` and `ram:ListEntitiesForPolicy` actions with Effect set to Allow.
 
-See the [Alibaba Cloud Resource Access Management documentation](https://www.alibabacloud.com/help/doc-detail/57445.htm?spm=a2c63.p38356.b99.12.51ef1b28W18VZd) and
-[documentation on authentication to RAM APIs](https://partners-intl.aliyun.com/help/doc-detail/102666.htm).
+{{% alibaba_access_management_doc %}}
+{{% alibaba_authentication_ram_api_doc %}}

--- a/docs-chef-io/content/inspec/resources/alicloud_ram_user.md
+++ b/docs-chef-io/content/inspec/resources/alicloud_ram_user.md
@@ -106,7 +106,7 @@ end
 
 ## Matchers
 
-This InSpec audit resource has the following special matchers. For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+{{% inspec_matchers_link %}}
 
 ### exist
 
@@ -142,5 +142,5 @@ This will check whether the requested user has a login profile for console acces
 
 Your Principal will need the following permissions action with Effect set to Allow: `ram:Getuser`, `ram:GetLoginProfile`, `ram:ListAccessKeys`.
 
-See the [Alibaba Cloud Resource Access Management documentation](https://www.alibabacloud.com/help/doc-detail/57445.htm?spm=a2c63.p38356.b99.12.51ef1b28W18VZd) and
-[documentation on authentication to RAM APIs](https://partners-intl.aliyun.com/help/doc-detail/102666.htm).
+{{% alibaba_access_management_doc %}}
+{{% alibaba_authentication_ram_api_doc %}}

--- a/docs-chef-io/content/inspec/resources/alicloud_ram_user_mfa.md
+++ b/docs-chef-io/content/inspec/resources/alicloud_ram_user_mfa.md
@@ -58,7 +58,7 @@ end
 
 ## Matchers
 
-This InSpec audit resource has the following special matchers. For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+{{% inspec_matchers_link %}}
 
 ### exist
 
@@ -76,7 +76,7 @@ it { should_not exist }
 
 ### Alicloud Permissions
 
-Your Principal will need the following permissions action with Effect set to Allow: `ram:GetUserMFAInfo`
+{{% alicloud_principal_action action="ram:GetUserMFAInfo" %}}
 
-See the [Alibaba Cloud Resource Access Management documentation](https://www.alibabacloud.com/help/doc-detail/57445.htm?spm=a2c63.p38356.b99.12.51ef1b28W18VZd) and
-[documentation on authentication to RAM APIs](https://partners-intl.aliyun.com/help/doc-detail/102666.htm).
+{{% alibaba_access_management_doc %}}
+{{% alibaba_authentication_ram_api_doc %}}

--- a/docs-chef-io/content/inspec/resources/alicloud_ram_users.md
+++ b/docs-chef-io/content/inspec/resources/alicloud_ram_users.md
@@ -139,6 +139,5 @@ end
 
 Your Principal will need the following permissions action with Effect set to Allow: `ram:Listusers`, `ram:GetLoginProfile`, `ram:ListAccessKeys`, `ram:GetUserMFAInfo`
 
-See the [Alibaba Cloud Resource Access Management documentation](https://www.alibabacloud.com/help/doc-detail/57445.htm?spm=a2c63.p38356.b99.12.51ef1b28W18VZd) and
-[documentation on authentication to RAM APIs](https://partners-intl.aliyun.com/help/doc-detail/102666.htm).
-
+{{% alibaba_access_management_doc %}}
+{{% alibaba_authentication_ram_api_doc %}}

--- a/docs-chef-io/layouts/shortcodes/alibaba_access_management_doc.md
+++ b/docs-chef-io/layouts/shortcodes/alibaba_access_management_doc.md
@@ -1,0 +1,2 @@
+
+See the [Alibaba Cloud Resource Access Management documentation](https://www.alibabacloud.com/help/doc-detail/57445.htm?spm=a2c63.p38356.b99.12.51ef1b28W18VZd).

--- a/docs-chef-io/layouts/shortcodes/alibaba_authentication_ecs_api_doc.md
+++ b/docs-chef-io/layouts/shortcodes/alibaba_authentication_ecs_api_doc.md
@@ -1,0 +1,2 @@
+
+See the [documentation on authentication rules for ECS APIs](https://partners-intl.aliyun.com/help/doc-detail/25497.htm?spm=a2c63.p38356.b99.657.7b9f3481VdEA4g).

--- a/docs-chef-io/layouts/shortcodes/alibaba_authentication_ram_api_doc.md
+++ b/docs-chef-io/layouts/shortcodes/alibaba_authentication_ram_api_doc.md
@@ -1,0 +1,2 @@
+
+See the [documentation on authentication to RAM APIs](https://partners-intl.aliyun.com/help/doc-detail/102666.htm).

--- a/docs-chef-io/layouts/shortcodes/alicloud_principal_action.md
+++ b/docs-chef-io/layouts/shortcodes/alicloud_principal_action.md
@@ -1,0 +1,2 @@
+
+Your Principal will need the `{{ .Get "action" }}` action with `Effect` set to `Allow`.

--- a/docs-chef-io/netlify.toml
+++ b/docs-chef-io/netlify.toml
@@ -1,0 +1,18 @@
+[build]
+
+[build.environment]
+  HUGO_VERSION = "0.93.1"
+  HUGO_ENABLEGITINFO = "true"
+  GO_VERSION = "1.15"
+  NODE_ENV = "development"
+
+[build.processing]
+  skip_processing = true
+
+[context.deploy-preview]
+  publish = "chef-web-docs/public"
+  command = "make preview_netlify"
+
+[context.production]
+  publish = "netlify_production"
+  command = ""


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>

### Description

A few things: 

- Adds a readme for the documentation
- Adds a Makefile so people can do local build previews of docs
- Adds a Netlify config so we can preview docs PRs
- converts some text to shortcodes
- edits the resource page template so it's more functional

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [ ] All Unit Tests pass
- [ ] `rake lint` passes
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
