### PR TITLE
Remove Hugo version from netlify config

### DIFF
--- a/docs-chef-io/netlify.toml
+++ b/docs-chef-io/netlify.toml
@@ -1,9 +1,7 @@
 [build]
 
 [build.environment]
-  HUGO_VERSION = "0.93.1"
   HUGO_ENABLEGITINFO = "true"
-  GO_VERSION = "1.15"
   NODE_ENV = "development"
 
 [build.processing]


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>

### Description

Remove Hugo version and go version from Netlify config. The current specified version causes build failures because of a bug and it's easier to specify these in the Netlify Web UI.

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [ ] All Unit Tests pass
- [ ] `rake lint` passes
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
