### PR TITLE
RESOURCE-386 ali-cloud-manual-implementation-of-resource-id-for-all-the-resources

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -92,6 +92,8 @@ Style/MultilineBlockChain:
   Enabled: false
 Lint/ReturnInVoidContext:
   Enabled: false
+Style/FormatStringToken:
+  Enabled: false
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     '%':  '{}'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,121 @@
+---
+AllCops:
+  Exclude:
+  - bin/**/*
+  - vendor/**/*
+  - dev/**/*
+  SuggestExtensions: false
+Layout/LineLength:
+  Enabled: false
+Layout/HashAlignment:
+  Enabled: false
+Layout/EmptyLineAfterMagicComment:
+  Enabled: false
+Layout/EndOfLine:
+  Enabled: true
+  EnforcedStyle: lf
+Layout/ExtraSpacing:
+  Enabled: true
+  Exclude:
+  - Gemfile
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+Layout/SpaceAroundOperators:
+  Enabled: false
+Layout/ParameterAlignment:
+  Enabled: true
+Layout/EmptyLinesAroundBlockBody:
+  Enabled: false
+Lint/MissingSuper:
+  Enabled: false
+Metrics/MethodLength:
+  Max: 60
+Metrics/AbcSize:
+  Max: 175
+Metrics/BlockLength:
+  Max: 50
+Metrics/ClassLength:
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Max: 125
+Metrics/PerceivedComplexity:
+  Max: 125
+Naming/VariableNumber:
+  Enabled: false
+Naming/FileName:
+  Enabled: false
+Naming/PredicateName:
+  Enabled: false
+Security/YAMLLoad:
+  Enabled: false
+Style/NumericLiterals:
+  MinDigits: 10
+Style/BlockDelimiters:
+  Enabled: false
+Style/Documentation:
+  Enabled: false
+Style/AndOr:
+  Enabled: false
+Style/ClassAndModuleChildren:
+  Enabled: false
+Style/ConditionalAssignment:
+  Enabled: false
+Style/DoubleNegation:
+  Enabled: false
+Style/EmptyMethod:
+  Enabled: false
+Style/Encoding:
+  Enabled: false
+Style/GuardClause:
+  Enabled: false
+Style/IfUnlessModifier:
+  Enabled: false
+Style/MissingRespondToMissing:
+  Enabled: false
+Style/MultilineIfModifier:
+  Enabled: false
+Style/NegatedIf:
+  Enabled: false
+Style/Not:
+  Enabled: false
+Style/NumericLiteralPrefix:
+  Enabled: false
+Style/NumericPredicate:
+  Enabled: false
+Style/HashTransformKeys:
+  Enabled: false
+Style/SlicingWithRange:
+  Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
+Style/MultilineBlockChain:
+  Enabled: false
+Lint/ReturnInVoidContext:
+  Enabled: false
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%':  '{}'
+    '%i': ()
+    '%q': '{}'
+    '%Q': ()
+    '%r': '{}'
+    '%s': ()
+    '%w': '{}'
+    '%W': ()
+    '%x': ()
+Style/SymbolArray:
+  Enabled: false
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: comma
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma
+Style/UnlessElse:
+  Enabled: false
+Style/ClassVars:
+  Enabled: false
+Style/FrozenStringLiteralComment:
+  Enabled: false
+Style/HashSyntax:
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -94,6 +94,8 @@ Lint/ReturnInVoidContext:
   Enabled: false
 Style/FormatStringToken:
   Enabled: false
+Style/StringLiterals:
+  Enabled: false
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     '%':  '{}'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,9 @@
 ---
 AllCops:
   Exclude:
-  - bin/**/*
-  - vendor/**/*
-  - dev/**/*
+    - bin/**/*
+    - vendor/**/*
+    - dev/**/*
   SuggestExtensions: false
 Layout/LineLength:
   Enabled: false
@@ -17,7 +17,7 @@ Layout/EndOfLine:
 Layout/ExtraSpacing:
   Enabled: true
   Exclude:
-  - Gemfile
+    - Gemfile
 Layout/EmptyLineAfterGuardClause:
   Enabled: false
 Layout/SpaceAroundOperators:
@@ -26,7 +26,13 @@ Layout/ParameterAlignment:
   Enabled: true
 Layout/EmptyLinesAroundBlockBody:
   Enabled: false
+Layout/MultilineMethodCallIndentation:
+  Enabled: false
+Style/StringLiteralsInInterpolation:
+  Enabled: false
 Lint/MissingSuper:
+  Enabled: false
+Layout/BlockAlignment:
   Enabled: false
 Metrics/MethodLength:
   Max: 60

--- a/Rakefile
+++ b/Rakefile
@@ -33,7 +33,7 @@ end
 # run tests
 #  Disabling inspec check on profile with path dependency due to https://github.com/inspec/inspec/issues/3571 - 'test:check'
 desc "Run robocop linter + unit tests"
-task default: %i{lint test}
+task default: [:lint, :test]
 
 namespace :test do
   task :check do
@@ -77,7 +77,7 @@ namespace :tf do
     sh(cmd)
   end
 
-  task plan_integration_tests: %i{tf_dir init_workspace} do
+  task plan_integration_tests: [:tf_dir, :init_workspace] do
     if File.exist?(TF_VAR_FILE)
       puts "----> Previous run not cleaned up - running cleanup..."
       Rake::Task["tf:cleanup_integration_tests"].execute
@@ -91,7 +91,7 @@ namespace :tf do
     sh(cmd)
   end
 
-  task setup_integration_tests: %i{tf_dir plan_integration_tests} do
+  task setup_integration_tests: [:tf_dir, :plan_integration_tests] do
     puts "----> Applying the plan"
     # Apply the plan on AliCloud
     cmd = format("terraform apply %s", TF_PLAN_FILE)

--- a/libraries/alicloud_actiontrail_trail.rb
+++ b/libraries/alicloud_actiontrail_trail.rb
@@ -18,7 +18,7 @@ class AliCloudActionTrailTrail < AliCloudResourceBase
     opts = { trail_name: opts } if opts.is_a?(String)
     @opts = opt
     super(opts)
-    validate_parameters(required: %i[trail_name region])
+    validate_parameters(required: %i(trail_name region))
 
     @trail_name = opts[:trail_name]
     catch_alicloud_errors do
@@ -26,8 +26,8 @@ class AliCloudActionTrailTrail < AliCloudResourceBase
         action: 'DescribeTrails',
         params: {
           "RegionId": opts[:region],
-          "NameList": @trail_name
-        }
+          "NameList": @trail_name,
+        },
       )['TrailList']
 
       return if resp.empty?
@@ -51,8 +51,8 @@ class AliCloudActionTrailTrail < AliCloudResourceBase
         action: 'GetTrailStatus',
         params: {
           "RegionId": opts[:region],
-          "Name": @trail_name
-        }
+          "Name": @trail_name,
+        },
       )
       # LatestDeliveryTime is unix time with milliseconds
       # Subtract two datetime objects for difference in days
@@ -72,8 +72,8 @@ class AliCloudActionTrailTrail < AliCloudResourceBase
         action: 'GetTrailStatus',
         params: {
           "RegionId": opts[:region],
-          "Name": @trail_name
-        }
+          "Name": @trail_name,
+        },
       )
       trail_status['IsLogging']
     end

--- a/libraries/alicloud_actiontrail_trail.rb
+++ b/libraries/alicloud_actiontrail_trail.rb
@@ -1,44 +1,45 @@
 # frozen_string_literal: true
 
-require "alicloud_backend"
+require 'alicloud_backend'
 
 class AliCloudActionTrailTrail < AliCloudResourceBase
-  name "alicloud_actiontrail_trail"
-  desc "Verifies settings for an individual AliCloud ActionTrail"
+  name 'alicloud_actiontrail_trail'
+  desc 'Verifies settings for an individual AliCloud ActionTrail'
 
   example "
     describe alicloud_actiontrail_trail('trail-name') do
       it { should exist }
     end
   "
-  attr_reader :trail_name, :oss_bucket_name, :oss_key_prefix, :role_name, :sls_project_arn, :sls_write_role_arn, :status, :trail_region
+  attr_reader :trail_name, :oss_bucket_name, :oss_key_prefix, :role_name, :sls_project_arn, :sls_write_role_arn,
+              :status, :trail_region
 
   def initialize(opts = {})
     opts = { trail_name: opts } if opts.is_a?(String)
     @opts = opt
     super(opts)
-    validate_parameters(required: %i{trail_name region})
+    validate_parameters(required: %i[trail_name region])
 
     @trail_name = opts[:trail_name]
     catch_alicloud_errors do
       resp = @alicloud.actiontrail_client.request(
-        action: "DescribeTrails",
+        action: 'DescribeTrails',
         params: {
           "RegionId": opts[:region],
-          "NameList": @trail_name,
+          "NameList": @trail_name
         }
-      )["TrailList"]
+      )['TrailList']
 
       return if resp.empty?
 
       @trail = resp.first
-      @oss_bucket_name = @trail["OssBucketName"]
-      @oss_key_prefix = @trail["OssKeyPrefix"]
-      @role_name = @trail["RoleName"]
-      @sls_project_arn = @trail["SlsProjectArn"]
-      @sls_write_role_arn = @trail["SlsWriteRoleArn"]
-      @status = @trail["Status"]
-      @trail_region = @trail["TrailRegion"]
+      @oss_bucket_name = @trail['OssBucketName']
+      @oss_key_prefix = @trail['OssKeyPrefix']
+      @role_name = @trail['RoleName']
+      @sls_project_arn = @trail['SlsProjectArn']
+      @sls_write_role_arn = @trail['SlsWriteRoleArn']
+      @status = @trail['Status']
+      @trail_region = @trail['TrailRegion']
     end
   end
 
@@ -47,16 +48,19 @@ class AliCloudActionTrailTrail < AliCloudResourceBase
 
     catch_alicloud_errors do
       trail_status = @alicloud.actiontrail_client.request(
-        action: "GetTrailStatus",
+        action: 'GetTrailStatus',
         params: {
           "RegionId": opts[:region],
-          "Name": @trail_name,
+          "Name": @trail_name
         }
       )
       # LatestDeliveryTime is unix time with milliseconds
       # Subtract two datetime objects for difference in days
       # May not exist if no logs have been delivered yet
-      (DateTime.now - DateTime.strptime(trail_status["LatestDeliveryTime"].to_s, "%Q")).to_i if trail_status["LatestDeliveryTime"]
+      if trail_status['LatestDeliveryTime']
+        (DateTime.now - DateTime.strptime(trail_status['LatestDeliveryTime'].to_s,
+                                          '%Q')).to_i
+      end
     end
   end
 
@@ -65,18 +69,22 @@ class AliCloudActionTrailTrail < AliCloudResourceBase
 
     catch_alicloud_errors do
       trail_status = @alicloud.actiontrail_client.request(
-        action: "GetTrailStatus",
+        action: 'GetTrailStatus',
         params: {
           "RegionId": opts[:region],
-          "Name": @trail_name,
+          "Name": @trail_name
         }
       )
-      trail_status["IsLogging"]
+      trail_status['IsLogging']
     end
   end
 
   def exists?
     !@trail.nil? && !@trail.empty?
+  end
+
+  def resource_id
+    @trail ? "#{@trail_name}_#{@trail[:RequestId]}" : @trail_name
   end
 
   def to_s

--- a/libraries/alicloud_actiontrail_trails.rb
+++ b/libraries/alicloud_actiontrail_trails.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "alicloud_backend"
+require 'alicloud_backend'
 
 class AliCloudActionTrailTrails < AliCloudResourceBase
-  name "alicloud_actiontrail_trails"
-  desc "Verifies settings for AliCloud Audit Trails in bulk"
+  name 'alicloud_actiontrail_trails'
+  desc 'Verifies settings for AliCloud Audit Trails in bulk'
   example '
     describe alicloud_actiontrail_trails do
       it { should exist }
@@ -17,39 +17,39 @@ class AliCloudActionTrailTrails < AliCloudResourceBase
     @opts = opts
     # Call the parent class constructor
     super(opts)
-    validate_parameters(required: %i{region})
+    validate_parameters(required: %i[region])
 
     @table = fetch_data
   end
 
   FilterTable.create
-    .register_column(:names,               field: :name)
-    .register_column(:oss_bucket_names,    field: :oss_bucket_name)
-    .register_column(:oss_key_prefixes,    field: :oss_key_prefix)
-    .register_column(:role_names,          field: :role_name)
-    .register_column(:sls_project_arns,    field: :sls_project_arn)
-    .register_column(:sls_write_role_arns, field: :sls_write_role_arn)
-    .install_filter_methods_on_resource(self, :table)
+             .register_column(:names,               field: :name)
+             .register_column(:oss_bucket_names,    field: :oss_bucket_name)
+             .register_column(:oss_key_prefixes,    field: :oss_key_prefix)
+             .register_column(:role_names,          field: :role_name)
+             .register_column(:sls_project_arns,    field: :sls_project_arn)
+             .register_column(:sls_write_role_arns, field: :sls_write_role_arn)
+             .install_filter_methods_on_resource(self, :table)
 
   def fetch_data
     actiontrail_rows = []
     catch_alicloud_errors do
       @actiontrails = @alicloud.actiontrail_client.request(
-        action: "DescribeTrails",
+        action: 'DescribeTrails',
         params: {
-          "RegionId": opts[:region],
+          "RegionId": opts[:region]
         }
-      )["TrailList"]
+      )['TrailList']
     end
     return [] if !@actiontrails || @actiontrails.empty?
 
     @actiontrails.each do |actiontrail|
-      actiontrail_rows += [{ name: actiontrail["Name"],
-                             oss_bucket_name: actiontrail["OssBucketName"],
-                             oss_key_prefix: actiontrail["OssKeyPrefix"],
-                             role_name: actiontrail["RoleName"],
-                             sls_project_arn: actiontrail["SlsProjectArn"],
-                             sls_write_role_arn: actiontrail["SlsWriteRoleArn"] }]
+      actiontrail_rows += [{ name: actiontrail['Name'],
+                             oss_bucket_name: actiontrail['OssBucketName'],
+                             oss_key_prefix: actiontrail['OssKeyPrefix'],
+                             role_name: actiontrail['RoleName'],
+                             sls_project_arn: actiontrail['SlsProjectArn'],
+                             sls_write_role_arn: actiontrail['SlsWriteRoleArn'] }]
     end
     @table = actiontrail_rows
   end

--- a/libraries/alicloud_actiontrail_trails.rb
+++ b/libraries/alicloud_actiontrail_trails.rb
@@ -17,7 +17,7 @@ class AliCloudActionTrailTrails < AliCloudResourceBase
     @opts = opts
     # Call the parent class constructor
     super(opts)
-    validate_parameters(required: %i[region])
+    validate_parameters(required: %i(region))
 
     @table = fetch_data
   end
@@ -37,8 +37,8 @@ class AliCloudActionTrailTrails < AliCloudResourceBase
       @actiontrails = @alicloud.actiontrail_client.request(
         action: 'DescribeTrails',
         params: {
-          "RegionId": opts[:region]
-        }
+          "RegionId": opts[:region],
+        },
       )['TrailList']
     end
     return [] if !@actiontrails || @actiontrails.empty?

--- a/libraries/alicloud_apsaradb_rds_instance.rb
+++ b/libraries/alicloud_apsaradb_rds_instance.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "alicloud_backend"
+require 'alicloud_backend'
 
 class AliCloudApsaradbRdsInstance < AliCloudResourceBase
-  name "alicloud_apsaradb_rds_instance"
-  desc "Verifies settings for an ApsaraDB RDS instance"
+  name 'alicloud_apsaradb_rds_instance'
+  desc 'Verifies settings for an ApsaraDB RDS instance'
 
   example "
     describe alicloud_apsaradb_rds_instance(db_instance_id: 'test-instance-id') do
@@ -32,42 +32,42 @@ class AliCloudApsaradbRdsInstance < AliCloudResourceBase
     @rds_instance = fetch_db_info(opts)
     return if @rds_instance.nil?
 
-    @description       = @rds_instance["DBInstanceDescription"]
-    @instance_type     = @rds_instance["DBInstanceType"] # Primary/Readonly/Guard/Temp
-    @category          = @rds_instance["Category"] # Basic/HighAvailability/AlwaysOn/Finance
-    @engine            = @rds_instance["Engine"]
-    @engine_version    = @rds_instance["EngineVersion"]
-    @allocated_storage = @rds_instance["DBInstanceStorage"]
-    @storage_type      = @rds_instance["DBInstanceStorageType"]
-    @memory            = @rds_instance["DBInstanceMemory"]
-    @cpus              = @rds_instance["DBInstanceCPU"].to_i
-    @instance_class    = @rds_instance["DBInstanceClass"]
-    @pay_type          = @rds_instance["PayType"]
-    @status            = @rds_instance["DBInstanceStatus"] # Running
-    @network_type      = @rds_instance["InstanceNetworkType"] # Classic/VPC
-    @net_type          = @rds_instance["DBInstanceNetType"] # Internet / Intranet
-    @vpc_id            = @rds_instance["VpcId"]
-    @zone_id           = @rds_instance["ZoneId"]
-    @security_ips      = @rds_instance["SecurityIPList"]
-    @security_ip_mode  = @rds_instance["SecurityIPMode"] # normal (standard whitelist mode)/safety (enhanced whitelist mode)
+    @description       = @rds_instance['DBInstanceDescription']
+    @instance_type     = @rds_instance['DBInstanceType'] # Primary/Readonly/Guard/Temp
+    @category          = @rds_instance['Category'] # Basic/HighAvailability/AlwaysOn/Finance
+    @engine            = @rds_instance['Engine']
+    @engine_version    = @rds_instance['EngineVersion']
+    @allocated_storage = @rds_instance['DBInstanceStorage']
+    @storage_type      = @rds_instance['DBInstanceStorageType']
+    @memory            = @rds_instance['DBInstanceMemory']
+    @cpus              = @rds_instance['DBInstanceCPU'].to_i
+    @instance_class    = @rds_instance['DBInstanceClass']
+    @pay_type          = @rds_instance['PayType']
+    @status            = @rds_instance['DBInstanceStatus'] # Running
+    @network_type      = @rds_instance['InstanceNetworkType'] # Classic/VPC
+    @net_type          = @rds_instance['DBInstanceNetType'] # Internet / Intranet
+    @vpc_id            = @rds_instance['VpcId']
+    @zone_id           = @rds_instance['ZoneId']
+    @security_ips      = @rds_instance['SecurityIPList']
+    @security_ip_mode  = @rds_instance['SecurityIPMode'] # normal (standard whitelist mode)/safety (enhanced whitelist mode)
 
     opts[:vpc_id] = @vpc_id
     vpc_info = fetch_vpc_info(opts)
-    @in_default_vpc = vpc_info["IsDefault"]
+    @in_default_vpc = vpc_info['IsDefault']
   end
 
   def fetch_db_info(opts)
-    catch_alicloud_errors("InvalidDBInstanceId.NotFound") do
+    catch_alicloud_errors('InvalidDBInstanceId.NotFound') do
       resp = @alicloud.rds_client.request(
-        action: "DescribeDBInstanceAttribute",
+        action: 'DescribeDBInstanceAttribute',
         params: {
           RegionId: opts[:region],
-          DBInstanceId: opts[:db_instance_id],
+          DBInstanceId: opts[:db_instance_id]
         },
         opts: {
-          method: "POST",
+          method: 'POST'
         }
-      )["Items"]["DBInstanceAttribute"][0]
+      )['Items']['DBInstanceAttribute'][0]
       return resp
     end
   end
@@ -75,10 +75,10 @@ class AliCloudApsaradbRdsInstance < AliCloudResourceBase
   def fetch_vpc_info(opts)
     catch_alicloud_errors do
       resp = @alicloud.vpc_client.request(
-        action: "DescribeVpcAttribute",
+        action: 'DescribeVpcAttribute',
         params: {
           'RegionId': opts[:region],
-          'VpcId': opts[:vpc_id],
+          'VpcId': opts[:vpc_id]
         }
       )
       return resp
@@ -87,6 +87,10 @@ class AliCloudApsaradbRdsInstance < AliCloudResourceBase
 
   def exists?
     !@rds_instance.nil? && !@rds_instance.empty?
+  end
+
+  def resource_id
+    @instance_id
   end
 
   def to_s

--- a/libraries/alicloud_apsaradb_rds_instance.rb
+++ b/libraries/alicloud_apsaradb_rds_instance.rb
@@ -62,11 +62,11 @@ class AliCloudApsaradbRdsInstance < AliCloudResourceBase
         action: 'DescribeDBInstanceAttribute',
         params: {
           RegionId: opts[:region],
-          DBInstanceId: opts[:db_instance_id]
+          DBInstanceId: opts[:db_instance_id],
         },
         opts: {
-          method: 'POST'
-        }
+          method: 'POST',
+        },
       )['Items']['DBInstanceAttribute'][0]
       return resp
     end
@@ -78,8 +78,8 @@ class AliCloudApsaradbRdsInstance < AliCloudResourceBase
         action: 'DescribeVpcAttribute',
         params: {
           'RegionId': opts[:region],
-          'VpcId': opts[:vpc_id]
-        }
+          'VpcId': opts[:vpc_id],
+        },
       )
       return resp
     end

--- a/libraries/alicloud_apsaradb_rds_instances.rb
+++ b/libraries/alicloud_apsaradb_rds_instances.rb
@@ -89,7 +89,7 @@ class AliCloudApsaradbRdsInstances < AliCloudResourceBase
           connection_mode: rds_instance['ConnectionMode'],
           vpc_cloud_instance_id: rds_instance['VpcCloudInstanceId'],
           region_id: rds_instance['RegionId'],
-          expire_time: rds_instance['ExpireTime']
+          expire_time: rds_instance['ExpireTime'],
         }]
       end
 
@@ -103,11 +103,11 @@ class AliCloudApsaradbRdsInstances < AliCloudResourceBase
       resp = @alicloud.rds_client.request(
         action: 'DescribeDBInstances',
         params: {
-          RegionId: opts[:region]
+          RegionId: opts[:region],
         },
         opts: {
-          method: 'POST'
-        }
+          method: 'POST',
+        },
       )
       return resp
     end

--- a/libraries/alicloud_apsaradb_rds_instances.rb
+++ b/libraries/alicloud_apsaradb_rds_instances.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "alicloud_backend"
+require 'alicloud_backend'
 
 class AliCloudApsaradbRdsInstances < AliCloudResourceBase
-  name "alicloud_apsaradb_rds_instances"
-  desc "Verifies settings for ApsaraDB RDS instances in bulk"
+  name 'alicloud_apsaradb_rds_instances'
+  desc 'Verifies settings for ApsaraDB RDS instances in bulk'
   example "
     describe alicloud_apsaradb_rds_instances do
       it { should exist }
@@ -26,30 +26,30 @@ class AliCloudApsaradbRdsInstances < AliCloudResourceBase
   attr_reader :table
 
   FilterTable.create
-    .register_column(:db_instance_ids, field: :db_instance_id)
-    .register_column(:descriptions, field: :description)
-    .register_column(:resource_groups, field: :resource_group)
-    .register_column(:net_types, field: :net_type)
-    .register_column(:instance_types, field: :instance_type)
-    .register_column(:multiple_zone_deployments, field: :multiple_zone_deployment)
-    .register_column(:network_types, field: :network_type)
-    .register_column(:read_only_instance_ids, field: :read_only_instance_list)
-    .register_column(:engines, field: :engine)
-    .register_column(:engine_versions, field: :engine_version)
-    .register_column(:statuses, field: :status)
-    .register_column(:zone_ids, field: :zone_id)
-    .register_column(:instance_classes, field: :instance_class)
-    .register_column(:create_times, field: :create_time)
-    .register_column(:vswitch_ids, field: :vswitch_id)
-    .register_column(:pay_types, field: :pay_type)
-    .register_column(:lock_modes, field: :lock_mode)
-    .register_column(:storage_types, field: :storage_type)
-    .register_column(:vpc_ids, field: :vpc_id)
-    .register_column(:connection_modes, field: :connection_mode)
-    .register_column(:vpc_cloud_instance_ids, field: :vpc_cloud_instance_id)
-    .register_column(:region_ids, field: :region_id)
-    .register_column(:expire_times, field: :expire_time)
-    .install_filter_methods_on_resource(self, :table)
+             .register_column(:db_instance_ids, field: :db_instance_id)
+             .register_column(:descriptions, field: :description)
+             .register_column(:resource_groups, field: :resource_group)
+             .register_column(:net_types, field: :net_type)
+             .register_column(:instance_types, field: :instance_type)
+             .register_column(:multiple_zone_deployments, field: :multiple_zone_deployment)
+             .register_column(:network_types, field: :network_type)
+             .register_column(:read_only_instance_ids, field: :read_only_instance_list)
+             .register_column(:engines, field: :engine)
+             .register_column(:engine_versions, field: :engine_version)
+             .register_column(:statuses, field: :status)
+             .register_column(:zone_ids, field: :zone_id)
+             .register_column(:instance_classes, field: :instance_class)
+             .register_column(:create_times, field: :create_time)
+             .register_column(:vswitch_ids, field: :vswitch_id)
+             .register_column(:pay_types, field: :pay_type)
+             .register_column(:lock_modes, field: :lock_mode)
+             .register_column(:storage_types, field: :storage_type)
+             .register_column(:vpc_ids, field: :vpc_id)
+             .register_column(:connection_modes, field: :connection_mode)
+             .register_column(:vpc_cloud_instance_ids, field: :vpc_cloud_instance_id)
+             .register_column(:region_ids, field: :region_id)
+             .register_column(:expire_times, field: :expire_time)
+             .install_filter_methods_on_resource(self, :table)
 
   def initialize(opts = {})
     super(opts)
@@ -61,35 +61,35 @@ class AliCloudApsaradbRdsInstances < AliCloudResourceBase
       @api_response = fetch_data(opts)
       return [] if !@api_response || @api_response.empty?
 
-      total_record_count = @api_response["TotalRecordCount"]
-      page_record_count = @api_response["PageRecordCount"]
+      total_record_count = @api_response['TotalRecordCount']
+      page_record_count = @api_response['PageRecordCount']
       total_records_returned += page_record_count
 
-      @api_response["Items"]["DBInstance"].each do |rds_instance|
+      @api_response['Items']['DBInstance'].each do |rds_instance|
         rds_instance_rows += [{
-          db_instance_id:           rds_instance["DBInstanceId"],
-          description:              rds_instance["DBInstanceDescription"],
-          resource_group:           rds_instance["ResourceGroupId"],
-          net_type:                 rds_instance["DBInstanceNetType"],
-          instance_type:            rds_instance["DBInstanceType"],
-          multiple_zone_deployment: rds_instance["MutriORsignle"],
-          network_type:             rds_instance["InstanceNetworkType"],
-          read_only_instance_list:  rds_instance["ReadOnlyDBInstanceIds"]["ReadOnlyDBInstanceId"],
-          engine:                   rds_instance["Engine"],
-          engine_version:           rds_instance["EngineVersion"],
-          status:                   rds_instance["DBInstanceStatus"],
-          zone_id:                  rds_instance["ZoneId"],
-          instance_class:           rds_instance["DBInstanceClass"],
-          create_time:              rds_instance["CreateTime"],
-          vswitch_id:               rds_instance["VSwitchId"],
-          pay_type:                 rds_instance["PayType"],
-          lock_mode:                rds_instance["LockMode"],
-          storage_type:             rds_instance["DBInstanceStorageType"],
-          vpc_id:                   rds_instance["VpcId"],
-          connection_mode:          rds_instance["ConnectionMode"],
-          vpc_cloud_instance_id:    rds_instance["VpcCloudInstanceId"],
-          region_id:                rds_instance["RegionId"],
-          expire_time:              rds_instance["ExpireTime"],
+          db_instance_id: rds_instance['DBInstanceId'],
+          description: rds_instance['DBInstanceDescription'],
+          resource_group: rds_instance['ResourceGroupId'],
+          net_type: rds_instance['DBInstanceNetType'],
+          instance_type: rds_instance['DBInstanceType'],
+          multiple_zone_deployment: rds_instance['MutriORsignle'],
+          network_type: rds_instance['InstanceNetworkType'],
+          read_only_instance_list: rds_instance['ReadOnlyDBInstanceIds']['ReadOnlyDBInstanceId'],
+          engine: rds_instance['Engine'],
+          engine_version: rds_instance['EngineVersion'],
+          status: rds_instance['DBInstanceStatus'],
+          zone_id: rds_instance['ZoneId'],
+          instance_class: rds_instance['DBInstanceClass'],
+          create_time: rds_instance['CreateTime'],
+          vswitch_id: rds_instance['VSwitchId'],
+          pay_type: rds_instance['PayType'],
+          lock_mode: rds_instance['LockMode'],
+          storage_type: rds_instance['DBInstanceStorageType'],
+          vpc_id: rds_instance['VpcId'],
+          connection_mode: rds_instance['ConnectionMode'],
+          vpc_cloud_instance_id: rds_instance['VpcCloudInstanceId'],
+          region_id: rds_instance['RegionId'],
+          expire_time: rds_instance['ExpireTime']
         }]
       end
 
@@ -101,12 +101,12 @@ class AliCloudApsaradbRdsInstances < AliCloudResourceBase
   def fetch_data(opts)
     catch_alicloud_errors do
       resp = @alicloud.rds_client.request(
-        action: "DescribeDBInstances",
+        action: 'DescribeDBInstances',
         params: {
-          RegionId: opts[:region],
+          RegionId: opts[:region]
         },
         opts: {
-          method: "POST",
+          method: 'POST'
         }
       )
       return resp

--- a/libraries/alicloud_backend.rb
+++ b/libraries/alicloud_backend.rb
@@ -30,15 +30,15 @@ class AliCloudConnection
     region ||= ENV['ALICLOUD_REGION']
 
     endpoint = @client_args.fetch(:endpoint, nil) if @client_args
-    endpoint ||= if %w[sts ram resourcemanager ims rds].include?(api)
+    endpoint ||= if %w{sts ram resourcemanager ims rds}.include?(api)
                    "https://#{api}.aliyuncs.com"
-                 elsif %w[vpc
-                          slb].include?(api) && %w[cn-qingdao cn-beijing cn-beijing cn-shanghai cn-shenzhen cn-hongkong ap-southeast-1 us-west-1
-                                                   us-east-1 cn-shanghai-finance-1 cn-shenzhen-finance-1 cn-north-2-gov-1].include?(region)
+                 elsif %w{vpc
+                          slb}.include?(api) && %w{cn-qingdao cn-beijing cn-beijing cn-shanghai cn-shenzhen cn-hongkong ap-southeast-1 us-west-1
+                                                   us-east-1 cn-shanghai-finance-1 cn-shenzhen-finance-1 cn-north-2-gov-1}.include?(region)
                    # AliCloud VPN endpoints vary between regions, so the following accounts for that variability
                    "https://#{api}.aliyuncs.com"
-                 elsif api == 'ecs' && %w[cn-hongkong ap-southeast-1 us-west-1 us-east-1
-                                          cn-north-2-gov-1].include?(region)
+                 elsif api == 'ecs' && %w{cn-hongkong ap-southeast-1 us-west-1 us-east-1
+                                          cn-north-2-gov-1}.include?(region)
                    "https://#{api}.#{region}.aliyuncs.com"
                  else
                    "https://#{api}.#{region}.aliyuncs.com"
@@ -48,7 +48,7 @@ class AliCloudConnection
       access_key_secret: ENV['ALICLOUD_SECRET_KEY'],
       security_token: ENV['ALICLOUD_SECURITY_TOKEN'],
       endpoint: endpoint,
-      api_version: api_version
+      api_version: api_version,
     )
     AliCloudCommonClient.new(client)
   end
@@ -62,7 +62,7 @@ class AliCloudConnection
       endpoint: endpoint,
       access_key_id: ENV['ALICLOUD_ACCESS_KEY'],
       access_key_secret: ENV['ALICLOUD_SECRET_KEY'],
-      sts_token: ENV['ALICLOUD_SECURITY_TOKEN']
+      sts_token: ENV['ALICLOUD_SECURITY_TOKEN'],
     )
   end
 
@@ -130,7 +130,7 @@ class AliCloudCommonClient
       response = @client.request(
         action: action,
         params: params,
-        opts: opts
+        opts: opts,
       )
       if response_total.nil?
         response_total = response
@@ -224,8 +224,8 @@ class AliCloudResourceBase < Inspec.resource(1)
       allow += require_any_of
     end
 
-    allow += %i[region] unless allow.include?(:region)
-    allow += %i[endpoint] unless allow.include?(:endpoint)
+    allow += %i(region) unless allow.include?(:region)
+    allow += %i(endpoint) unless allow.include?(:endpoint)
     @opts.delete(:region) if @opts.is_a?(Hash) && @opts[:region].nil?
 
     raise ArgumentError, 'Scalar arguments not supported' unless defined?(@opts.keys)

--- a/libraries/alicloud_backend.rb
+++ b/libraries/alicloud_backend.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require "aliyunsdkcore"
-require "aliyun/oss"
-require "rspec/expectations"
+require 'aliyunsdkcore'
+require 'aliyun/oss'
+require 'rspec/expectations'
 
 # AliCloud Inspec Backend Classes
 #
@@ -26,62 +26,63 @@ class AliCloudConnection
   end
 
   def alicloud_client(api:, api_version:)
-    region = @client_args.fetch(:region, nil) || ENV["ALICLOUD_REGION"] if @client_args
-    region ||= ENV["ALICLOUD_REGION"]
+    region = @client_args.fetch(:region, nil) || ENV['ALICLOUD_REGION'] if @client_args
+    region ||= ENV['ALICLOUD_REGION']
 
     endpoint = @client_args.fetch(:endpoint, nil) if @client_args
-    endpoint ||= if %w{sts ram resourcemanager ims rds}.include?(api)
+    endpoint ||= if %w[sts ram resourcemanager ims rds].include?(api)
                    "https://#{api}.aliyuncs.com"
-                 else
+                 elsif %w[vpc
+                          slb].include?(api) && %w[cn-qingdao cn-beijing cn-beijing cn-shanghai cn-shenzhen cn-hongkong ap-southeast-1 us-west-1
+                                                   us-east-1 cn-shanghai-finance-1 cn-shenzhen-finance-1 cn-north-2-gov-1].include?(region)
                    # AliCloud VPN endpoints vary between regions, so the following accounts for that variability
-                   if %w{vpc slb}.include?(api) && %w{cn-qingdao cn-beijing cn-beijing cn-shanghai cn-shenzhen cn-hongkong ap-southeast-1 us-west-1 us-east-1 cn-shanghai-finance-1 cn-shenzhen-finance-1 cn-north-2-gov-1}.include?(region)
-                     "https://#{api}.aliyuncs.com"
-                   elsif api == "ecs" && %w{cn-hongkong ap-southeast-1 us-west-1 us-east-1 cn-north-2-gov-1}.include?(region)
-                     "https://#{api}.#{region}.aliyuncs.com"
-                   else
-                     "https://#{api}.#{region}.aliyuncs.com"
-                   end
+                   "https://#{api}.aliyuncs.com"
+                 elsif api == 'ecs' && %w[cn-hongkong ap-southeast-1 us-west-1 us-east-1
+                                          cn-north-2-gov-1].include?(region)
+                   "https://#{api}.#{region}.aliyuncs.com"
+                 else
+                   "https://#{api}.#{region}.aliyuncs.com"
                  end
     client = RPCClient.new(
-      access_key_id:     ENV["ALICLOUD_ACCESS_KEY"],
-      access_key_secret: ENV["ALICLOUD_SECRET_KEY"],
-      security_token:    ENV["ALICLOUD_SECURITY_TOKEN"],
-      endpoint:          endpoint,
-      api_version:       api_version
+      access_key_id: ENV['ALICLOUD_ACCESS_KEY'],
+      access_key_secret: ENV['ALICLOUD_SECRET_KEY'],
+      security_token: ENV['ALICLOUD_SECURITY_TOKEN'],
+      endpoint: endpoint,
+      api_version: api_version
     )
     AliCloudCommonClient.new(client)
   end
 
   def aliyun_oss_client
-    region = @client_args.fetch(:region, nil) || ENV["ALICLOUD_REGION"] if @client_args
-    region ||= ENV["ALICLOUD_REGION"]
+    region = @client_args.fetch(:region, nil) || ENV['ALICLOUD_REGION'] if @client_args
+    region ||= ENV['ALICLOUD_REGION']
 
     endpoint = "https://oss-#{region}.aliyuncs.com"
     Aliyun::OSS::Client.new(
       endpoint: endpoint,
-      access_key_id: ENV["ALICLOUD_ACCESS_KEY"],
-      access_key_secret: ENV["ALICLOUD_SECRET_KEY"],
-      sts_token:    ENV["ALICLOUD_SECURITY_TOKEN"]
+      access_key_id: ENV['ALICLOUD_ACCESS_KEY'],
+      access_key_secret: ENV['ALICLOUD_SECRET_KEY'],
+      sts_token: ENV['ALICLOUD_SECURITY_TOKEN']
     )
   end
 
   def unique_identifier
     # use alicloud account id
-    caller_identity = sts_client.request(action: "GetCallerIdentity")
-    caller_identity["AccountId"]
+    caller_identity = sts_client.request(action: 'GetCallerIdentity')
+    caller_identity['AccountId']
   end
 
   # Client convenience methods
   def actiontrail_client
-    alicloud_client(api: "actiontrail", api_version: "2017-12-04")
+    alicloud_client(api: 'actiontrail', api_version: '2017-12-04')
   end
 
   def slb_client
-    alicloud_client(api: "slb", api_version: "2014-05-15")
+    alicloud_client(api: 'slb', api_version: '2014-05-15')
   end
 
   def ecs_client
-    alicloud_client(api: "ecs", api_version: "2014-05-26")
+    alicloud_client(api: 'ecs', api_version: '2014-05-26')
   end
 
   def oss_client
@@ -89,27 +90,27 @@ class AliCloudConnection
   end
 
   def sts_client
-    alicloud_client(api: "sts", api_version: "2015-04-01")
+    alicloud_client(api: 'sts', api_version: '2015-04-01')
   end
 
   def ram_client
-    alicloud_client(api: "ram", api_version: "2015-05-01")
+    alicloud_client(api: 'ram', api_version: '2015-05-01')
   end
 
   def rm_client
-    alicloud_client(api: "resourcemanager", api_version: "2020-03-31")
+    alicloud_client(api: 'resourcemanager', api_version: '2020-03-31')
   end
 
   def vpc_client
-    alicloud_client(api: "vpc", api_version: "2016-04-28")
+    alicloud_client(api: 'vpc', api_version: '2016-04-28')
   end
 
   def ims_client
-    alicloud_client(api: "ims", api_version: "2019-08-15")
+    alicloud_client(api: 'ims', api_version: '2019-08-15')
   end
 
   def rds_client
-    alicloud_client(api: "rds", api_version: "2014-08-15")
+    alicloud_client(api: 'rds', api_version: '2014-08-15')
   end
 end
 
@@ -150,7 +151,9 @@ class AliCloudCommonClient
         end
       end
       # stop looping if the response is not paginated or has reached the last page
-      break if response["PageNumber"].nil? || response["PageSize"].nil? || (page_number * response["PageSize"] >= response["TotalCount"])
+      if response['PageNumber'].nil? || response['PageSize'].nil? || (page_number * response['PageSize'] >= response['TotalCount'])
+        break
+      end
 
       page_number += 1
     end
@@ -172,7 +175,7 @@ class AliCloudResourceBase < Inspec.resource(1)
       # below allows each resource to optionally and conveniently set an endpoint
       client_args[:endpoint] = opts[:endpoint] if opts[:endpoint]
       # Default region to ALICLOUD_REGION env var - needed in the resource requests for most resources
-      @opts[:region] ||= ENV["ALICLOUD_REGION"]
+      @opts[:region] ||= ENV['ALICLOUD_REGION']
     end
     @alicloud = AliCloudConnection.new(client_args)
   end
@@ -183,27 +186,51 @@ class AliCloudResourceBase < Inspec.resource(1)
   # If a parameter is entirely optional, use `allow`
   def validate_parameters(allow: [], required: nil, require_any_of: nil)
     if required
-      raise ArgumentError, "Expected required parameters as Array of Symbols, got #{required}" unless required.is_a?(Array) && required.all? { |r| r.is_a?(Symbol) }
-      raise ArgumentError, "#{@__resource_name__}: region must be provided via environment variable or hash parameter" if required.include?(:region) && (!@opts.is_a?(Hash) || (@opts[:region].nil? || @opts[:region] == ""))
-      raise ArgumentError, "#{@__resource_name__}: `#{required}` must be provided" unless @opts.is_a?(Hash) && required.all? { |req| @opts.key?(req) && !@opts[req].nil? && @opts[req] != "" }
+      unless required.is_a?(Array) && required.all? do |r|
+               r.is_a?(Symbol)
+             end
+        raise ArgumentError,
+              "Expected required parameters as Array of Symbols, got #{required}"
+      end
+
+      if required.include?(:region) && (!@opts.is_a?(Hash) || (@opts[:region].nil? || @opts[:region] == ''))
+        raise ArgumentError,
+              "#{@__resource_name__}: region must be provided via environment variable or hash parameter"
+      end
+      unless @opts.is_a?(Hash) && required.all? do |req|
+               @opts.key?(req) && !@opts[req].nil? && @opts[req] != ''
+             end
+        raise ArgumentError,
+              "#{@__resource_name__}: `#{required}` must be provided"
+      end
 
       allow += required
     end
 
     if require_any_of
-      raise ArgumentError, "Expected required parameters as Array of Symbols, got #{require_any_of}" unless require_any_of.is_a?(Array) && require_any_of.all? { |r| r.is_a?(Symbol) }
-      raise ArgumentError, "#{@__resource_name__}: One of `#{require_any_of}` must be provided." unless @opts.is_a?(Hash) && require_any_of.any? { |req| @opts.key?(req) && !@opts[req].nil? && @opts[req] != "" }
+      unless require_any_of.is_a?(Array) && require_any_of.all? do |r|
+               r.is_a?(Symbol)
+             end
+        raise ArgumentError,
+              "Expected required parameters as Array of Symbols, got #{require_any_of}"
+      end
+      unless @opts.is_a?(Hash) && require_any_of.any? do |req|
+               @opts.key?(req) && !@opts[req].nil? && @opts[req] != ''
+             end
+        raise ArgumentError,
+              "#{@__resource_name__}: One of `#{require_any_of}` must be provided."
+      end
 
       allow += require_any_of
     end
 
-    allow += %i{region} unless allow.include?(:region)
-    allow += %i{endpoint} unless allow.include?(:endpoint)
+    allow += %i[region] unless allow.include?(:region)
+    allow += %i[endpoint] unless allow.include?(:endpoint)
     @opts.delete(:region) if @opts.is_a?(Hash) && @opts[:region].nil?
 
-    raise ArgumentError, "Scalar arguments not supported" unless defined?(@opts.keys)
-    raise ArgumentError, "Unexpected arguments found" unless @opts.keys.all? { |a| allow.include?(a) }
-    raise ArgumentError, "Provided parameter should not be empty" unless @opts.values.all? do |a|
+    raise ArgumentError, 'Scalar arguments not supported' unless defined?(@opts.keys)
+    raise ArgumentError, 'Unexpected arguments found' unless @opts.keys.all? { |a| allow.include?(a) }
+    raise ArgumentError, 'Provided parameter should not be empty' unless @opts.values.all? do |a|
       return true if a.instance_of?(Integer) || a.instance_of?(TrueClass) || a.instance_of?(FalseClass)
 
       !a.empty?
@@ -220,14 +247,14 @@ class AliCloudResourceBase < Inspec.resource(1)
   def catch_alicloud_errors(ignore = [])
     yield # Catch and create custom messages as needed
   rescue ArgumentError
-    Inspec::Log.error "It appears that you have not set your AliCloud credentials."
-    fail_resource("No AliCloud credentials available")
+    Inspec::Log.error 'It appears that you have not set your AliCloud credentials.'
+    fail_resource('No AliCloud credentials available')
   rescue StandardError => e
-    ignore = [ ignore ] if ignore.is_a?(String)
+    ignore = [ignore] if ignore.is_a?(String)
     ignore.each { |error| return nil if e.message =~ /\b#{error}\b/ }
     Inspec::Log.warn "AliCloud Service Error encountered running a control with Resource #{@__resource_name__}. " \
                       "Error message: #{e.message}. You should address this error to ensure your controls are " \
-                      "behaving as expected."
+                      'behaving as expected.'
     @failed_resource = true
     nil
   end

--- a/libraries/alicloud_disk.rb
+++ b/libraries/alicloud_disk.rb
@@ -24,7 +24,7 @@ class AliCloudDisk < AliCloudResourceBase
     opts[:disk_name] = opts.delete(:name) if opts.key?(:name) # name is an alias for disk_name
     @opts = opts
     super(opts)
-    validate_parameters(require_any_of: %i[disk_id disk_name], required: %i[region])
+    validate_parameters(require_any_of: %i(disk_id disk_name), required: %i(region))
 
     if opts[:disk_id] && !opts[:disk_id].empty?
       if opts[:disk_id] !~ /^d-[0-9a-z]+$/
@@ -64,8 +64,8 @@ class AliCloudDisk < AliCloudResourceBase
         action: 'DescribeDisks',
         params: filters,
         opts: {
-          method: 'POST'
-        }
+          method: 'POST',
+        },
       )['Disks']['Disk']
 
       disk = if opts.key?(:disk_id)

--- a/libraries/alicloud_disk.rb
+++ b/libraries/alicloud_disk.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "alicloud_backend"
+require 'alicloud_backend'
 
 class AliCloudDisk < AliCloudResourceBase
-  name "alicloud_disk"
-  desc "Verifies properties for an individual AliCloud disk"
+  name 'alicloud_disk'
+  desc 'Verifies properties for an individual AliCloud disk'
   example "
   describe alicloud_disks('disk-12345678') do
     it { should exist }
@@ -24,10 +24,13 @@ class AliCloudDisk < AliCloudResourceBase
     opts[:disk_name] = opts.delete(:name) if opts.key?(:name) # name is an alias for disk_name
     @opts = opts
     super(opts)
-    validate_parameters(require_any_of: %i{disk_id disk_name}, required: %i{region})
+    validate_parameters(require_any_of: %i[disk_id disk_name], required: %i[region])
 
     if opts[:disk_id] && !opts[:disk_id].empty?
-      raise ArgumentError, "#{@__resource_name__}: disk ID must be in the format 'd- followed by alphanumeric characters." if opts[:disk_id] !~ /^d\-[0-9a-z]+$/
+      if opts[:disk_id] !~ /^d-[0-9a-z]+$/
+        raise ArgumentError,
+              "#{@__resource_name__}: disk ID must be in the format 'd- followed by alphanumeric characters."
+      end
       raise ArgumentError, "#{@__resource_name__}: expected only one of `disk_id` or `disk_name`" if opts[:disk_name]
     elsif !opts[:disk_name] || opts[:disk_name].empty?
       raise ArgumentError, "#{@__resource_name__}: `disk_id` or `disk_name` must be provided"
@@ -40,16 +43,16 @@ class AliCloudDisk < AliCloudResourceBase
     end
 
     @disk                 = @resp
-    @id                   = @disk["DiskId"]
-    @name                 = @disk["DiskName"]
-    @description          = @disk["Description"]
-    @size                 = @disk["Size"]
-    @category             = @disk["Category"]
-    @encrypted            = @disk["Encrypted"]
-    @kms_key_id           = @disk["KMSKeyId"]
-    @enable_auto_snapshot = @disk["EnableAutoSnapshot"]
-    @delete_auto_snapshot = @disk["DeleteAutoSnapshot"]
-    @delete_with_instance = @disk["DeleteWithInstance"]
+    @id                   = @disk['DiskId']
+    @name                 = @disk['DiskName']
+    @description          = @disk['Description']
+    @size                 = @disk['Size']
+    @category             = @disk['Category']
+    @encrypted            = @disk['Encrypted']
+    @kms_key_id           = @disk['KMSKeyId']
+    @enable_auto_snapshot = @disk['EnableAutoSnapshot']
+    @delete_auto_snapshot = @disk['DeleteAutoSnapshot']
+    @delete_with_instance = @disk['DeleteWithInstance']
   end
 
   def fetch_disk_info(opts)
@@ -58,18 +61,18 @@ class AliCloudDisk < AliCloudResourceBase
 
     catch_alicloud_errors do
       resp = @alicloud.ecs_client.request(
-        action: "DescribeDisks",
+        action: 'DescribeDisks',
         params: filters,
-       opts: {
-         method: "POST",
-       }
-      )["Disks"]["Disk"]
+        opts: {
+          method: 'POST'
+        }
+      )['Disks']['Disk']
 
-      if opts.key?(:disk_id)
-        disk = resp.select { |d| d["DiskId"] == opts[:disk_id] }.first
-      else
-        disk = resp.select { |d| d["DiskName"] == opts[:disk_name] }.first
-      end
+      disk = if opts.key?(:disk_id)
+               resp.select { |d| d['DiskId'] == opts[:disk_id] }.first
+             else
+               resp.select { |d| d['DiskName'] == opts[:disk_name] }.first
+             end
       return disk
     end
   end
@@ -80,6 +83,10 @@ class AliCloudDisk < AliCloudResourceBase
 
   def exists?
     !@disk.nil?
+  end
+
+  def resource_id
+    @id
   end
 
   def to_s

--- a/libraries/alicloud_disks.rb
+++ b/libraries/alicloud_disks.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "alicloud_backend"
+require 'alicloud_backend'
 
 class AliCloudDisks < AliCloudResourceBase
-  name "alicloud_disks"
-  desc "Verifies settings for AliCloud disks in bulk"
+  name 'alicloud_disks'
+  desc 'Verifies settings for AliCloud disks in bulk'
   example "
     # Verify that you have disks defined
     describe alicloud_disks do
@@ -27,21 +27,21 @@ class AliCloudDisks < AliCloudResourceBase
 
   # FilterTable setup
   FilterTable.create
-    .register_column(:ids, field: :id)
-    .register_column(:names, field: :name)
-    .register_column(:descriptions, field: :description)
-    .register_column(:sizes, field: :size)
-    .register_column(:categories, field: :category)
-    .register_column(:encrypted_disks, field: :encrypted)
-    .register_column(:kms_key_ids, field: :kms_key_id)
-    .register_column(:enable_auto_snapshot, field: :enable_auto_snapshot)
-    .register_column(:delete_auto_snapshot, field: :delete_auto_snapshot)
-    .register_column(:delete_with_instance, field: :delete_with_instance)
-    .install_filter_methods_on_resource(self, :table)
+             .register_column(:ids, field: :id)
+             .register_column(:names, field: :name)
+             .register_column(:descriptions, field: :description)
+             .register_column(:sizes, field: :size)
+             .register_column(:categories, field: :category)
+             .register_column(:encrypted_disks, field: :encrypted)
+             .register_column(:kms_key_ids, field: :kms_key_id)
+             .register_column(:enable_auto_snapshot, field: :enable_auto_snapshot)
+             .register_column(:delete_auto_snapshot, field: :delete_auto_snapshot)
+             .register_column(:delete_with_instance, field: :delete_with_instance)
+             .install_filter_methods_on_resource(self, :table)
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters(required: %i{region})
+    validate_parameters(required: %i[region])
 
     @disks = fetch_data
     return [] if !@disks || @disks.empty?
@@ -49,16 +49,16 @@ class AliCloudDisks < AliCloudResourceBase
     disk_rows = []
     @disks.map do |disk|
       disk_rows += [{
-        id: disk["DiskId"],
-        name: disk["DiskName"],
-        description: disk["Description"],
-        size: disk["Size"],
-        category: disk["Category"],
-        encrypted: disk["Encrypted"],
-        kms_key_id: disk["KMSKeyId"],
-        enable_auto_snapshot: disk["EnableAutoSnapshot"],
-        delete_auto_snapshot: disk["DeleteAutoSnapshot"],
-        delete_with_instance: disk["DeleteWithInstance"],
+        id: disk['DiskId'],
+        name: disk['DiskName'],
+        description: disk['Description'],
+        size: disk['Size'],
+        category: disk['Category'],
+        encrypted: disk['Encrypted'],
+        kms_key_id: disk['KMSKeyId'],
+        enable_auto_snapshot: disk['EnableAutoSnapshot'],
+        delete_auto_snapshot: disk['DeleteAutoSnapshot'],
+        delete_with_instance: disk['DeleteWithInstance']
       }]
     end
 
@@ -68,11 +68,11 @@ class AliCloudDisks < AliCloudResourceBase
   def fetch_data
     catch_alicloud_errors do
       disks = @alicloud.ecs_client.request(
-        action: "DescribeDisks",
+        action: 'DescribeDisks',
         params: {
-          RegionId: opts[:region],
+          RegionId: opts[:region]
         }
-      )["Disks"]["Disk"]
+      )['Disks']['Disk']
       return disks
     end
   end

--- a/libraries/alicloud_disks.rb
+++ b/libraries/alicloud_disks.rb
@@ -41,7 +41,7 @@ class AliCloudDisks < AliCloudResourceBase
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters(required: %i[region])
+    validate_parameters(required: %i(region))
 
     @disks = fetch_data
     return [] if !@disks || @disks.empty?
@@ -58,7 +58,7 @@ class AliCloudDisks < AliCloudResourceBase
         kms_key_id: disk['KMSKeyId'],
         enable_auto_snapshot: disk['EnableAutoSnapshot'],
         delete_auto_snapshot: disk['DeleteAutoSnapshot'],
-        delete_with_instance: disk['DeleteWithInstance']
+        delete_with_instance: disk['DeleteWithInstance'],
       }]
     end
 
@@ -70,8 +70,8 @@ class AliCloudDisks < AliCloudResourceBase
       disks = @alicloud.ecs_client.request(
         action: 'DescribeDisks',
         params: {
-          RegionId: opts[:region]
-        }
+          RegionId: opts[:region],
+        },
       )['Disks']['Disk']
       return disks
     end

--- a/libraries/alicloud_ecs_instance.rb
+++ b/libraries/alicloud_ecs_instance.rb
@@ -25,7 +25,7 @@ class AliCloudECSInstance < AliCloudResourceBase
     opts[:instance_id] = opts.delete(:id) if opts.key?(:id) # id is an alias for group_id
     @opts = opts
     super(opts)
-    validate_parameters(required: %i[instance_id region])
+    validate_parameters(required: %i(instance_id region))
 
     @instance = fetch_instance(opts)['Instances']['Instance'].first
     return if @instance.nil?
@@ -76,11 +76,11 @@ class AliCloudECSInstance < AliCloudResourceBase
         action: 'DescribeInstances',
         params: {
           'RegionId': opts[:region],
-          'InstanceIds': "[\"#{opts[:instance_id]}\"]"
+          'InstanceIds': "[\"#{opts[:instance_id]}\"]",
         },
         opts: {
-          method: 'POST'
-        }
+          method: 'POST',
+        },
       )
       return resp
     end
@@ -92,11 +92,11 @@ class AliCloudECSInstance < AliCloudResourceBase
         action: 'DescribeInstanceAttribute',
         params: {
           'RegionId': opts[:region],
-          'InstanceId': opts[:instance_id]
+          'InstanceId': opts[:instance_id],
         },
         opts: {
-          method: 'POST'
-        }
+          method: 'POST',
+        },
       )
       return resp
     end
@@ -108,11 +108,11 @@ class AliCloudECSInstance < AliCloudResourceBase
         action: 'DescribeInstanceRamRole',
         params: {
           RegionId: opts[:region],
-          InstanceIds: "[\"#{opts[:instance_id]}\"]"
+          InstanceIds: "[\"#{opts[:instance_id]}\"]",
         },
         opts: {
-          method: 'POST'
-        }
+          method: 'POST',
+        },
       )['InstanceRamRoleSets']['InstanceRamRoleSet'].map { |r| r['RamRoleName'] }
       return resp
     end

--- a/libraries/alicloud_ecs_instance.rb
+++ b/libraries/alicloud_ecs_instance.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "alicloud_backend"
+require 'alicloud_backend'
 
 class AliCloudECSInstance < AliCloudResourceBase
-  name "alicloud_ecs_instance"
-  desc "Verifies settings for an individual ecs instance"
+  name 'alicloud_ecs_instance'
+  desc 'Verifies settings for an individual ecs instance'
 
   example '
   # verify an instance exists
@@ -25,61 +25,61 @@ class AliCloudECSInstance < AliCloudResourceBase
     opts[:instance_id] = opts.delete(:id) if opts.key?(:id) # id is an alias for group_id
     @opts = opts
     super(opts)
-    validate_parameters(required: %i{instance_id region})
+    validate_parameters(required: %i[instance_id region])
 
-    @instance = fetch_instance(opts)["Instances"]["Instance"].first
+    @instance = fetch_instance(opts)['Instances']['Instance'].first
     return if @instance.nil?
 
-    @deletion_protection = @instance["DeletionProtection"]
+    @deletion_protection = @instance['DeletionProtection']
 
     @ram_roles = fetch_instance_ram_roles(opts)
 
     @instance_attributes = fetch_instance_attributes(opts)
     return if @instance_attributes.nil?
 
-    @description                = @instance_attributes["Description"]
-    @memory                     = @instance_attributes["Memory"]
-    @instance_charge_type       = @instance_attributes["InstanceChargeType"]
-    @cpu                        = @instance_attributes["Cpu"]
-    @instance_network_type      = @instance_attributes["InstanceNetworkType"]
-    @public_ip_address          = @instance_attributes["PublicIpAddress"]["IpAddress"]
-    @inner_ip_address           = @instance_attributes["InnerIpAddress"]["IpAddress"]
-    @expired_time               = @instance_attributes["ExpiredTime"]
-    @image_id                   = @instance_attributes["ImageId"]
-    @eip_address                = @instance_attributes["EipAddress"]
-    @instance_type              = @instance_attributes["InstanceType"]
-    @host_name                  = @instance_attributes["HostName"]
-    @vlan_id                    = @instance_attributes["VlanId"]
-    @status                     = @instance_attributes["Status"]
-    @io_optimized               = @instance_attributes["IoOptimized"]
-    @zone_id                    = @instance_attributes["ZoneId"]
-    @instance_id                = @instance_attributes["InstanceId"]
-    @cluster_id                 = @instance_attributes["ClusterId"]
-    @stopped_mode               = @instance_attributes["StoppedMode"]
-    @dedicated_host_attribute   = @instance_attributes["DedicatedHostAttribute"]
-    @security_group_ids         = @instance_attributes["SecurityGroupIds"]
-    @vpc_attributes             = @instance_attributes["VpcAttributes"]
-    @operation_locks            = @instance_attributes["OperationLocks"]
-    @internet_charge_type       = @instance_attributes["InternetChargeType"]
-    @instance_name              = @instance_attributes["InstanceName"]
-    @internet_max_bandwidth_out = @instance_attributes["InternetMaxBandwidthOut"]
-    @internet_max_bandwidth_in  = @instance_attributes["InternetMaxBandwidthIn"]
-    @serial_number              = @instance_attributes["SerialNumber"]
-    @creation_time              = @instance_attributes["CreationTime"]
-    @region_id                  = @instance_attributes["RegionId"]
-    @credit_specification       = @instance_attributes["CreditSpecification"]
+    @description                = @instance_attributes['Description']
+    @memory                     = @instance_attributes['Memory']
+    @instance_charge_type       = @instance_attributes['InstanceChargeType']
+    @cpu                        = @instance_attributes['Cpu']
+    @instance_network_type      = @instance_attributes['InstanceNetworkType']
+    @public_ip_address          = @instance_attributes['PublicIpAddress']['IpAddress']
+    @inner_ip_address           = @instance_attributes['InnerIpAddress']['IpAddress']
+    @expired_time               = @instance_attributes['ExpiredTime']
+    @image_id                   = @instance_attributes['ImageId']
+    @eip_address                = @instance_attributes['EipAddress']
+    @instance_type              = @instance_attributes['InstanceType']
+    @host_name                  = @instance_attributes['HostName']
+    @vlan_id                    = @instance_attributes['VlanId']
+    @status                     = @instance_attributes['Status']
+    @io_optimized               = @instance_attributes['IoOptimized']
+    @zone_id                    = @instance_attributes['ZoneId']
+    @instance_id                = @instance_attributes['InstanceId']
+    @cluster_id                 = @instance_attributes['ClusterId']
+    @stopped_mode               = @instance_attributes['StoppedMode']
+    @dedicated_host_attribute   = @instance_attributes['DedicatedHostAttribute']
+    @security_group_ids         = @instance_attributes['SecurityGroupIds']
+    @vpc_attributes             = @instance_attributes['VpcAttributes']
+    @operation_locks            = @instance_attributes['OperationLocks']
+    @internet_charge_type       = @instance_attributes['InternetChargeType']
+    @instance_name              = @instance_attributes['InstanceName']
+    @internet_max_bandwidth_out = @instance_attributes['InternetMaxBandwidthOut']
+    @internet_max_bandwidth_in  = @instance_attributes['InternetMaxBandwidthIn']
+    @serial_number              = @instance_attributes['SerialNumber']
+    @creation_time              = @instance_attributes['CreationTime']
+    @region_id                  = @instance_attributes['RegionId']
+    @credit_specification       = @instance_attributes['CreditSpecification']
   end
 
   def fetch_instance(opts)
     catch_alicloud_errors do
       resp = @alicloud.ecs_client.request(
-        action: "DescribeInstances",
+        action: 'DescribeInstances',
         params: {
           'RegionId': opts[:region],
-          'InstanceIds': "[\"#{opts[:instance_id]}\"]",
+          'InstanceIds': "[\"#{opts[:instance_id]}\"]"
         },
         opts: {
-          method: "POST",
+          method: 'POST'
         }
       )
       return resp
@@ -89,13 +89,13 @@ class AliCloudECSInstance < AliCloudResourceBase
   def fetch_instance_attributes(opts)
     catch_alicloud_errors do
       resp = @alicloud.ecs_client.request(
-        action: "DescribeInstanceAttribute",
+        action: 'DescribeInstanceAttribute',
         params: {
           'RegionId': opts[:region],
-          'InstanceId': opts[:instance_id],
+          'InstanceId': opts[:instance_id]
         },
         opts: {
-          method: "POST",
+          method: 'POST'
         }
       )
       return resp
@@ -105,21 +105,25 @@ class AliCloudECSInstance < AliCloudResourceBase
   def fetch_instance_ram_roles(opts)
     catch_alicloud_errors do
       resp = @alicloud.ecs_client.request(
-        action: "DescribeInstanceRamRole",
+        action: 'DescribeInstanceRamRole',
         params: {
           RegionId: opts[:region],
-          InstanceIds: "[\"#{opts[:instance_id]}\"]",
+          InstanceIds: "[\"#{opts[:instance_id]}\"]"
         },
         opts: {
-          method: "POST",
+          method: 'POST'
         }
-      )["InstanceRamRoleSets"]["InstanceRamRoleSet"].map { |r| r["RamRoleName"] }
+      )['InstanceRamRoleSets']['InstanceRamRoleSet'].map { |r| r['RamRoleName'] }
       return resp
     end
   end
 
   def exists?
     !@instance.nil? && !@instance.empty?
+  end
+
+  def resource_id
+    @opts ? @opts[:instance_id] : ''
   end
 
   def to_s

--- a/libraries/alicloud_ecs_instances.rb
+++ b/libraries/alicloud_ecs_instances.rb
@@ -64,7 +64,7 @@ class AliCloudECSInstances < AliCloudResourceBase
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters(required: %i[region])
+    validate_parameters(required: %i(region))
 
     @instances = fetch_data
     return [] if !@instances || @instances.empty?
@@ -117,7 +117,7 @@ class AliCloudECSInstances < AliCloudResourceBase
         os_names_en: instance['OSNameEn'],
         spot_strategy: instance['SpotStrategy'],
         deletion_protection: instance['DeletionProtection'],
-        ram_role: fetch_instance_ram_roles(opts[:region], instance_id)
+        ram_role: fetch_instance_ram_roles(opts[:region], instance_id),
       }]
     end
 
@@ -129,8 +129,8 @@ class AliCloudECSInstances < AliCloudResourceBase
       resp = @alicloud.ecs_client.request(
         action: 'DescribeInstances',
         params: {
-          'RegionId': opts[:region]
-        }
+          'RegionId': opts[:region],
+        },
       )['Instances']['Instance']
       return resp
     end
@@ -142,11 +142,11 @@ class AliCloudECSInstances < AliCloudResourceBase
         action: 'DescribeInstanceRamRole',
         params: {
           RegionId: region,
-          InstanceIds: [instance_id].to_json
+          InstanceIds: [instance_id].to_json,
         },
         opts: {
-          method: 'POST'
-        }
+          method: 'POST',
+        },
       )['InstanceRamRoleSets']['InstanceRamRoleSet'].map { |r| r['RamRoleName'] }
       return resp
     end

--- a/libraries/alicloud_ecs_instances.rb
+++ b/libraries/alicloud_ecs_instances.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "alicloud_backend"
+require 'alicloud_backend'
 
 class AliCloudECSInstances < AliCloudResourceBase
-  name "alicloud_ecs_instances"
-  desc "Verifies settings for AliCloud instances in bulk"
+  name 'alicloud_ecs_instances'
+  desc 'Verifies settings for AliCloud instances in bulk'
   example "
   # verify more than 1 instance exists
   describe alicloud_ecs_instances do
@@ -15,109 +15,109 @@ class AliCloudECSInstances < AliCloudResourceBase
   attr_reader :table
 
   FilterTable.create
-    .register_column(:instance_ids, field: :instance_id)
-    .register_column(:instance_names, field: :instance_name)
-    .register_column(:host_names, field: :host_name)
-    .register_column(:descriptions, field: :description)
-    .register_column(:memory, field: :memory)
-    .register_column(:instance_charge_types, field: :instance_charge_type)
-    .register_column(:cpus, field: :cpu)
-    .register_column(:os_names, field: :os_name)
-    .register_column(:instance_network_types, field: :instance_network_type)
-    .register_column(:inner_ip_addresses, field: :inner_ip_address)
-    .register_column(:expired_times, field: :expired_time)
-    .register_column(:image_ids, field: :image_id)
-    .register_column(:eip_addresses, field: :eip_address)
-    .register_column(:vlan_ids, field: :vlan_id)
-    .register_column(:statuses, field: :status)
-    .register_column(:io_optimized, field: :io_optimized)
-    .register_column(:metadata_options, field: :metadata_options)
-    .register_column(:zone_ids, field: :zone_id)
-    .register_column(:cluster_ids, field: :cluster_id)
-    .register_column(:stopped_modes, field: :stopped_mode)
-    .register_column(:cpu_options, field: :cpu_options)
-    .register_column(:start_times, field: :start_time)
-    .register_column(:security_group_ids, field: :security_group_ids)
-    .register_column(:vpc_attributes, field: :vpc_attributes)
-    .register_column(:internet_charge_types, field: :internet_charge_type)
-    .register_column(:deployment_set_ids, field: :deployment_set_id)
-    .register_column(:internet_max_bandwidth_out, field: :internet_max_bandwidth_out)
-    .register_column(:internet_max_bandwidth_in, field: :internet_max_bandwidth_in)
-    .register_column(:serial_numbers, field: :serial_number)
-    .register_column(:os_types, field: :os_type)
-    .register_column(:creation_times, field: :creation_time)
-    .register_column(:auto_release_times, field: :auto_release_time)
-    .register_column(:instance_type_families, field: :instance_type_family)
-    .register_column(:dedicated_instance_attributes, field: :dedicated_instance_attribute)
-    .register_column(:public_ip_addresses, field: :public_ip_address)
-    .register_column(:gpu_specs, field: :gpu_spec)
-    .register_column(:network_interfaces, field: :network_interfaces)
-    .register_column(:spot_price_limits, field: :spot_price_limit)
-    .register_column(:devices_available, field: :device_available)
-    .register_column(:sale_cycles, field: :sale_cycle)
-    .register_column(:instance_types, field: :instance_type)
-    .register_column(:os_names_en, field: :os_names_en)
-    .register_column(:spot_strategies, field: :spot_strategy)
-    .register_column(:deletion_protections, field: :deletion_protection)
-    .register_column(:ram_roles, field: :ram_role)
-    .install_filter_methods_on_resource(self, :table)
+             .register_column(:instance_ids, field: :instance_id)
+             .register_column(:instance_names, field: :instance_name)
+             .register_column(:host_names, field: :host_name)
+             .register_column(:descriptions, field: :description)
+             .register_column(:memory, field: :memory)
+             .register_column(:instance_charge_types, field: :instance_charge_type)
+             .register_column(:cpus, field: :cpu)
+             .register_column(:os_names, field: :os_name)
+             .register_column(:instance_network_types, field: :instance_network_type)
+             .register_column(:inner_ip_addresses, field: :inner_ip_address)
+             .register_column(:expired_times, field: :expired_time)
+             .register_column(:image_ids, field: :image_id)
+             .register_column(:eip_addresses, field: :eip_address)
+             .register_column(:vlan_ids, field: :vlan_id)
+             .register_column(:statuses, field: :status)
+             .register_column(:io_optimized, field: :io_optimized)
+             .register_column(:metadata_options, field: :metadata_options)
+             .register_column(:zone_ids, field: :zone_id)
+             .register_column(:cluster_ids, field: :cluster_id)
+             .register_column(:stopped_modes, field: :stopped_mode)
+             .register_column(:cpu_options, field: :cpu_options)
+             .register_column(:start_times, field: :start_time)
+             .register_column(:security_group_ids, field: :security_group_ids)
+             .register_column(:vpc_attributes, field: :vpc_attributes)
+             .register_column(:internet_charge_types, field: :internet_charge_type)
+             .register_column(:deployment_set_ids, field: :deployment_set_id)
+             .register_column(:internet_max_bandwidth_out, field: :internet_max_bandwidth_out)
+             .register_column(:internet_max_bandwidth_in, field: :internet_max_bandwidth_in)
+             .register_column(:serial_numbers, field: :serial_number)
+             .register_column(:os_types, field: :os_type)
+             .register_column(:creation_times, field: :creation_time)
+             .register_column(:auto_release_times, field: :auto_release_time)
+             .register_column(:instance_type_families, field: :instance_type_family)
+             .register_column(:dedicated_instance_attributes, field: :dedicated_instance_attribute)
+             .register_column(:public_ip_addresses, field: :public_ip_address)
+             .register_column(:gpu_specs, field: :gpu_spec)
+             .register_column(:network_interfaces, field: :network_interfaces)
+             .register_column(:spot_price_limits, field: :spot_price_limit)
+             .register_column(:devices_available, field: :device_available)
+             .register_column(:sale_cycles, field: :sale_cycle)
+             .register_column(:instance_types, field: :instance_type)
+             .register_column(:os_names_en, field: :os_names_en)
+             .register_column(:spot_strategies, field: :spot_strategy)
+             .register_column(:deletion_protections, field: :deletion_protection)
+             .register_column(:ram_roles, field: :ram_role)
+             .install_filter_methods_on_resource(self, :table)
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters(required: %i{region})
+    validate_parameters(required: %i[region])
 
     @instances = fetch_data
     return [] if !@instances || @instances.empty?
 
     instance_rows = []
     @instances.map do |instance|
-      instance_id = instance["InstanceId"]
+      instance_id = instance['InstanceId']
 
       instance_rows += [{
-          instance_id:                  instance_id,
-          instance_name:                instance["InstanceName"],
-          host_name:                    instance["HostName"],
-          description:                  instance["Description"],
-          memory:                       instance["Memory"],
-          instance_charge_type:         instance["InstanceChargeType"],
-          cpu:                          instance["Cpu"],
-          os_name:                      instance["OSName"],
-          instance_network_type:        instance["InstanceNetworkType"],
-          inner_ip_address:             instance["InnerIpAddress"]["IpAddress"],
-          expired_time:                 instance["ExpiredTime"],
-          image_id:                     instance["ImageId"],
-          eip_address:                  instance["EipAddress"],
-          vlan_id:                      instance["VlanId"],
-          status:                       instance["Status"],
-          io_optimized:                 instance["IoOptimized"],
-          metadata_options:             instance["MetadataOptions"],
-          zone_id:                      instance["ZoneId"],
-          stopped_mode:                 instance["StoppedMode"],
-          cpu_options:                  instance["CpuOptions"],
-          start_time:                   instance["StartTime"],
-          security_group_ids:           instance["SecurityGroupIds"],
-          vpc_attributes:               instance["VpcAttributes"],
-          internet_charge_type:         instance["InternetChargeType"],
-          deployment_set_id:            instance["DeploymentSetId"],
-          internet_max_bandwidth_out:   instance["InternetMaxBandwidthOut"],
-          internet_max_bandwidth_in:    instance["InternetMaxBandwidthIn"],
-          serial_number:                instance["SerialNumber"],
-          os_type:                      instance["OSType"],
-          creation_time:                instance["CreationTime"],
-          auto_release_time:            instance["AutoReleaseTime"],
-          instance_type_family:         instance["InstanceTypeFamily"],
-          dedicated_instance_attribute: instance["DedicatedInstanceAttribute"],
-          public_ip_address:            instance["PublicIpAddress"],
-          gpu_spec:                     instance["GPUSpec"],
-          network_interfaces:           instance["NetworkInterfaces"],
-          spot_price_limit:             instance["SpotPriceLimit"],
-          device_available:             instance["DeviceAvailable"],
-          sale_cycle:                   instance["SaleCycle"],
-          instance_type:                instance["InstanceType"],
-          os_names_en:                  instance["OSNameEn"],
-          spot_strategy:                instance["SpotStrategy"],
-          deletion_protection:          instance["DeletionProtection"],
-          ram_role:                     fetch_instance_ram_roles(opts[:region], instance_id),
+        instance_id: instance_id,
+        instance_name: instance['InstanceName'],
+        host_name: instance['HostName'],
+        description: instance['Description'],
+        memory: instance['Memory'],
+        instance_charge_type: instance['InstanceChargeType'],
+        cpu: instance['Cpu'],
+        os_name: instance['OSName'],
+        instance_network_type: instance['InstanceNetworkType'],
+        inner_ip_address: instance['InnerIpAddress']['IpAddress'],
+        expired_time: instance['ExpiredTime'],
+        image_id: instance['ImageId'],
+        eip_address: instance['EipAddress'],
+        vlan_id: instance['VlanId'],
+        status: instance['Status'],
+        io_optimized: instance['IoOptimized'],
+        metadata_options: instance['MetadataOptions'],
+        zone_id: instance['ZoneId'],
+        stopped_mode: instance['StoppedMode'],
+        cpu_options: instance['CpuOptions'],
+        start_time: instance['StartTime'],
+        security_group_ids: instance['SecurityGroupIds'],
+        vpc_attributes: instance['VpcAttributes'],
+        internet_charge_type: instance['InternetChargeType'],
+        deployment_set_id: instance['DeploymentSetId'],
+        internet_max_bandwidth_out: instance['InternetMaxBandwidthOut'],
+        internet_max_bandwidth_in: instance['InternetMaxBandwidthIn'],
+        serial_number: instance['SerialNumber'],
+        os_type: instance['OSType'],
+        creation_time: instance['CreationTime'],
+        auto_release_time: instance['AutoReleaseTime'],
+        instance_type_family: instance['InstanceTypeFamily'],
+        dedicated_instance_attribute: instance['DedicatedInstanceAttribute'],
+        public_ip_address: instance['PublicIpAddress'],
+        gpu_spec: instance['GPUSpec'],
+        network_interfaces: instance['NetworkInterfaces'],
+        spot_price_limit: instance['SpotPriceLimit'],
+        device_available: instance['DeviceAvailable'],
+        sale_cycle: instance['SaleCycle'],
+        instance_type: instance['InstanceType'],
+        os_names_en: instance['OSNameEn'],
+        spot_strategy: instance['SpotStrategy'],
+        deletion_protection: instance['DeletionProtection'],
+        ram_role: fetch_instance_ram_roles(opts[:region], instance_id)
       }]
     end
 
@@ -127,11 +127,11 @@ class AliCloudECSInstances < AliCloudResourceBase
   def fetch_data
     catch_alicloud_errors do
       resp = @alicloud.ecs_client.request(
-        action: "DescribeInstances",
+        action: 'DescribeInstances',
         params: {
-          'RegionId': opts[:region],
+          'RegionId': opts[:region]
         }
-      )["Instances"]["Instance"]
+      )['Instances']['Instance']
       return resp
     end
   end
@@ -139,15 +139,15 @@ class AliCloudECSInstances < AliCloudResourceBase
   def fetch_instance_ram_roles(region, instance_id)
     catch_alicloud_errors do
       resp = @alicloud.ecs_client.request(
-        action: "DescribeInstanceRamRole",
+        action: 'DescribeInstanceRamRole',
         params: {
           RegionId: region,
-          InstanceIds: [instance_id].to_json,
+          InstanceIds: [instance_id].to_json
         },
         opts: {
-          method: "POST",
+          method: 'POST'
         }
-      )["InstanceRamRoleSets"]["InstanceRamRoleSet"].map { |r| r["RamRoleName"] }
+      )['InstanceRamRoleSets']['InstanceRamRoleSet'].map { |r| r['RamRoleName'] }
       return resp
     end
   end
@@ -157,6 +157,6 @@ class AliCloudECSInstances < AliCloudResourceBase
   end
 
   def to_s
-    "AliCloud ECS Instances (All)"
+    'AliCloud ECS Instances (All)'
   end
 end

--- a/libraries/alicloud_ims_sso.rb
+++ b/libraries/alicloud_ims_sso.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "alicloud_backend"
+require 'alicloud_backend'
 
 class AliCloudSsoSettings < AliCloudResourceBase
-  name "alicloud_ims_sso"
-  desc "Verifies settings for AliCloud SSO settings"
+  name 'alicloud_ims_sso'
+  desc 'Verifies settings for AliCloud SSO settings'
   example "
   describe alicloud_ims_sso do
     it { should exist}
@@ -16,25 +16,25 @@ class AliCloudSsoSettings < AliCloudResourceBase
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters(required: %i{region})
+    validate_parameters(required: %i[region])
 
     catch_alicloud_errors do
       @resp = @alicloud.ims_client.request(
-        action: "GetSamlSsoSettings",
+        action: 'GetSamlSsoSettings',
         params: {
-          "RegionId": opts[:region],
+          "RegionId": opts[:region]
         }
       )
     end
 
-    if @resp.nil? || @resp["SamlSsoSettings"].nil?
+    if @resp.nil? || @resp['SamlSsoSettings'].nil?
       @sso_enabled = false
       @auxiliary_domain = nil
       return
     end
 
-    @sso_enabled = @resp["SamlSsoSettings"]["SsoEnabled"]
-    @auxiliary_domain = @resp["SamlSsoSettings"]["AuxiliaryDomain"]
+    @sso_enabled = @resp['SamlSsoSettings']['SsoEnabled']
+    @auxiliary_domain = @resp['SamlSsoSettings']['AuxiliaryDomain']
   end
 
   def exists?
@@ -46,6 +46,6 @@ class AliCloudSsoSettings < AliCloudResourceBase
   end
 
   def to_s
-    "AliCloud SSO Settings"
+    'AliCloud SSO Settings'
   end
 end

--- a/libraries/alicloud_ims_sso.rb
+++ b/libraries/alicloud_ims_sso.rb
@@ -16,14 +16,14 @@ class AliCloudSsoSettings < AliCloudResourceBase
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters(required: %i[region])
+    validate_parameters(required: %i(region))
 
     catch_alicloud_errors do
       @resp = @alicloud.ims_client.request(
         action: 'GetSamlSsoSettings',
         params: {
-          "RegionId": opts[:region]
-        }
+          "RegionId": opts[:region],
+        },
       )
     end
 

--- a/libraries/alicloud_oss_bucket.rb
+++ b/libraries/alicloud_oss_bucket.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "alicloud_backend"
+require 'alicloud_backend'
 
 class AliCloudOssBucket < AliCloudResourceBase
-  name "alicloud_oss_bucket"
-  desc "Verifies settings for an AliCloud OSS Bucket"
+  name 'alicloud_oss_bucket'
+  desc 'Verifies settings for an AliCloud OSS Bucket'
   example "
     describe alicloud_oss_bucket(bucket_name: 'test_bucket') do
       it { should exist }
@@ -16,7 +16,7 @@ class AliCloudOssBucket < AliCloudResourceBase
   def initialize(opts = {})
     opts = { bucket_name: opts } if opts.is_a?(String)
     super(opts)
-    validate_parameters(required: %i{bucket_name region})
+    validate_parameters(required: %i[bucket_name region])
 
     @bucket_name = opts[:bucket_name]
 
@@ -39,7 +39,7 @@ class AliCloudOssBucket < AliCloudResourceBase
     return false unless exists?
 
     catch_alicloud_errors do
-      @bucket_policy_status_public ||= @bucket.acl != "private"
+      @bucket_policy_status_public ||= @bucket.acl != 'private'
     end
   end
 
@@ -60,7 +60,6 @@ class AliCloudOssBucket < AliCloudResourceBase
       false
     rescue StandardError => e
       fail_resource("Unexpected error thrown: #{e}")
-
     end
   end
 
@@ -68,7 +67,7 @@ class AliCloudOssBucket < AliCloudResourceBase
     return false unless exists?
 
     catch_alicloud_errors do
-      @has_versioning_enabled ||= @bucket.versioning.status == "Enabled"
+      @has_versioning_enabled ||= @bucket.versioning.status == 'Enabled'
     end
   end
 
@@ -86,6 +85,10 @@ class AliCloudOssBucket < AliCloudResourceBase
     catch_alicloud_errors do
       @bucket_lifecycle_rules ||= @bucket.lifecycle
     end
+  end
+
+  def resource_id
+    @bucket ? @bucket[:bucket_name] : @bucket_name
   end
 
   def to_s

--- a/libraries/alicloud_oss_bucket.rb
+++ b/libraries/alicloud_oss_bucket.rb
@@ -16,7 +16,7 @@ class AliCloudOssBucket < AliCloudResourceBase
   def initialize(opts = {})
     opts = { bucket_name: opts } if opts.is_a?(String)
     super(opts)
-    validate_parameters(required: %i[bucket_name region])
+    validate_parameters(required: %i(bucket_name region))
 
     @bucket_name = opts[:bucket_name]
 

--- a/libraries/alicloud_oss_buckets.rb
+++ b/libraries/alicloud_oss_buckets.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "alicloud_backend"
+require 'alicloud_backend'
 
 class AliCloudOssBuckets < AliCloudResourceBase
-  name "alicloud_oss_buckets"
-  desc "Verifies settings for AliCloud OSS Buckets in bulk"
+  name 'alicloud_oss_buckets'
+  desc 'Verifies settings for AliCloud OSS Buckets in bulk'
   example "
     describe alicloud_oss_buckets do
       its('bucket_names') { should eq ['my_bucket'] }
@@ -14,12 +14,12 @@ class AliCloudOssBuckets < AliCloudResourceBase
   attr_reader :table
 
   FilterTable.create
-    .register_column(:bucket_names, field: :bucket_name)
-    .install_filter_methods_on_resource(self, :table)
+             .register_column(:bucket_names, field: :bucket_name)
+             .install_filter_methods_on_resource(self, :table)
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters(required: %i{region})
+    validate_parameters(required: %i[region])
     @table = fetch_data
   end
 

--- a/libraries/alicloud_oss_buckets.rb
+++ b/libraries/alicloud_oss_buckets.rb
@@ -19,7 +19,7 @@ class AliCloudOssBuckets < AliCloudResourceBase
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters(required: %i[region])
+    validate_parameters(required: %i(region))
     @table = fetch_data
   end
 

--- a/libraries/alicloud_ram_access_key.rb
+++ b/libraries/alicloud_ram_access_key.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "alicloud_backend"
+require 'alicloud_backend'
 
 class AliCloudAccessKey < AliCloudResourceBase
-  name "alicloud_access_key"
-  desc "Verifies properties of an AliCloud access key"
+  name 'alicloud_access_key'
+  desc 'Verifies properties of an AliCloud access key'
   example '
   # check key is active
   describe alicloud_access_key(<access key id>) do
@@ -18,26 +18,26 @@ class AliCloudAccessKey < AliCloudResourceBase
     opts = { access_key_id: opts } if opts.is_a?(String)
     @opts = opts
     super(opts)
-    validate_parameters(required: %i{access_key_id}, allow: %i{user_name})
+    validate_parameters(required: %i[access_key_id], allow: %i[user_name])
     @opts = opts
 
     catch_alicloud_errors do
       params = { "RegionId": opts[:region] }
       params[:UserName] = opts[:user_name] if opts.key?(:user_name)
       @keys = @alicloud.ram_client.request(
-        action: "ListAccessKeys",
-            params: params,
-            opts: {
-              method: "POST",
-            }
-      )["AccessKeys"]["AccessKey"]
+        action: 'ListAccessKeys',
+        params: params,
+        opts: {
+          method: 'POST'
+        }
+      )['AccessKeys']['AccessKey']
 
       @keys.map do |key|
         # rubocop:disable Style/Next
-        if key["AccessKeyId"] == opts[:access_key_id]
-          @access_key_id = key["AccessKeyId"]
-          @status = key["Status"]
-          @create_date = key["CreateDate"]
+        if key['AccessKeyId'] == opts[:access_key_id]
+          @access_key_id = key['AccessKeyId']
+          @status = key['Status']
+          @create_date = key['CreateDate']
           break
         end
         # rubocop:enable Style/Next
@@ -47,6 +47,10 @@ class AliCloudAccessKey < AliCloudResourceBase
 
   def exists?
     !@access_key_id.nil?
+  end
+
+  def resource_id
+    "#{@access_key_id|| @opts[:access_key_id]}_#{@opts[:region]}"
   end
 
   def to_s

--- a/libraries/alicloud_ram_access_key.rb
+++ b/libraries/alicloud_ram_access_key.rb
@@ -18,7 +18,7 @@ class AliCloudAccessKey < AliCloudResourceBase
     opts = { access_key_id: opts } if opts.is_a?(String)
     @opts = opts
     super(opts)
-    validate_parameters(required: %i[access_key_id], allow: %i[user_name])
+    validate_parameters(required: %i(access_key_id), allow: %i(user_name))
     @opts = opts
 
     catch_alicloud_errors do
@@ -28,8 +28,8 @@ class AliCloudAccessKey < AliCloudResourceBase
         action: 'ListAccessKeys',
         params: params,
         opts: {
-          method: 'POST'
-        }
+          method: 'POST',
+        },
       )['AccessKeys']['AccessKey']
 
       @keys.map do |key|
@@ -50,7 +50,7 @@ class AliCloudAccessKey < AliCloudResourceBase
   end
 
   def resource_id
-    "#{@access_key_id|| @opts[:access_key_id]}_#{@opts[:region]}"
+    "#{@access_key_id || @opts[:access_key_id]}_#{@opts[:region]}"
   end
 
   def to_s

--- a/libraries/alicloud_ram_access_keys.rb
+++ b/libraries/alicloud_ram_access_keys.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "alicloud_backend"
+require 'alicloud_backend'
 
 class AliCloudAccessKeys < AliCloudResourceBase
-  name "alicloud_access_keys"
-  desc "Verifies properties of AliCloud access keys"
+  name 'alicloud_access_keys'
+  desc 'Verifies properties of AliCloud access keys'
   example '
     # ensure no keys exist
     describe alicloud_access_keys do
@@ -16,25 +16,25 @@ class AliCloudAccessKeys < AliCloudResourceBase
 
   # FilterTable setup
   FilterTable.create
-    .register_column(:access_key_ids, field: :access_key_id)
-    .register_column(:statuses, field: :status)
-    .register_column(:create_dates, field: :create_date)
-    .install_filter_methods_on_resource(self, :table)
+             .register_column(:access_key_ids, field: :access_key_id)
+             .register_column(:statuses, field: :status)
+             .register_column(:create_dates, field: :create_date)
+             .install_filter_methods_on_resource(self, :table)
 
   def initialize(opts = {})
     opts = { user_name: opts } if opts.is_a?(String)
     super(opts)
-    validate_parameters(allow: %i{user_name}, required: %i{region})
+    validate_parameters(allow: %i[user_name], required: %i[region])
     catch_alicloud_errors do
       params = { "RegionId": opts[:region] }
       params[:UserName] = opts[:user_name] if opts.key?(:user_name)
       @keys = @alicloud.ram_client.request(
-        action: "ListAccessKeys",
-          params: params,
-          opts: {
-            method: "POST",
-          }
-      )["AccessKeys"]["AccessKey"]
+        action: 'ListAccessKeys',
+        params: params,
+        opts: {
+          method: 'POST'
+        }
+      )['AccessKeys']['AccessKey']
     end
 
     return [] if !@keys || @keys.empty?
@@ -42,9 +42,9 @@ class AliCloudAccessKeys < AliCloudResourceBase
     keys_rows = []
     @keys.map do |key|
       keys_rows += [{
-        access_key_id: key["AccessKeyId"],
-          status: key["Status"],
-          create_date: key["CreateDate"],
+        access_key_id: key['AccessKeyId'],
+        status: key['Status'],
+        create_date: key['CreateDate']
       }]
     end
 
@@ -56,6 +56,6 @@ class AliCloudAccessKeys < AliCloudResourceBase
   end
 
   def to_s
-    "Alicloud Access Keys (All)"
+    'Alicloud Access Keys (All)'
   end
 end

--- a/libraries/alicloud_ram_access_keys.rb
+++ b/libraries/alicloud_ram_access_keys.rb
@@ -24,7 +24,7 @@ class AliCloudAccessKeys < AliCloudResourceBase
   def initialize(opts = {})
     opts = { user_name: opts } if opts.is_a?(String)
     super(opts)
-    validate_parameters(allow: %i[user_name], required: %i[region])
+    validate_parameters(allow: %i(user_name), required: %i(region))
     catch_alicloud_errors do
       params = { "RegionId": opts[:region] }
       params[:UserName] = opts[:user_name] if opts.key?(:user_name)
@@ -32,8 +32,8 @@ class AliCloudAccessKeys < AliCloudResourceBase
         action: 'ListAccessKeys',
         params: params,
         opts: {
-          method: 'POST'
-        }
+          method: 'POST',
+        },
       )['AccessKeys']['AccessKey']
     end
 
@@ -44,7 +44,7 @@ class AliCloudAccessKeys < AliCloudResourceBase
       keys_rows += [{
         access_key_id: key['AccessKeyId'],
         status: key['Status'],
-        create_date: key['CreateDate']
+        create_date: key['CreateDate'],
       }]
     end
 

--- a/libraries/alicloud_ram_password_policy.rb
+++ b/libraries/alicloud_ram_password_policy.rb
@@ -23,17 +23,17 @@ class AliCloudRam < AliCloudResourceBase
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters(required: %i[region])
+    validate_parameters(required: %i(region))
 
     catch_alicloud_errors do
       @resp = @alicloud.ram_client.request(
         action: 'GetPasswordPolicy',
         params: {
-          'RegionId': opts[:region]
+          'RegionId': opts[:region],
         },
         opts: {
-          method: 'POST'
-        }
+          method: 'POST',
+        },
       )['PasswordPolicy']
     end
     if @resp.nil?

--- a/libraries/alicloud_ram_password_policy.rb
+++ b/libraries/alicloud_ram_password_policy.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "alicloud_backend"
+require 'alicloud_backend'
 
 class AliCloudRam < AliCloudResourceBase
-  name "alicloud_ram_password_policy"
-  desc "Verifies properties for an individual AliCloud RAM Password Policy"
+  name 'alicloud_ram_password_policy'
+  desc 'Verifies properties for an individual AliCloud RAM Password Policy'
   example "
   describe alicloud_ram_password_policy do
     it { should exist }
@@ -23,41 +23,45 @@ class AliCloudRam < AliCloudResourceBase
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters(required: %i{region})
+    validate_parameters(required: %i[region])
 
     catch_alicloud_errors do
       @resp = @alicloud.ram_client.request(
-        action: "GetPasswordPolicy",
+        action: 'GetPasswordPolicy',
         params: {
-          'RegionId': opts[:region],
+          'RegionId': opts[:region]
         },
         opts: {
-          method: "POST",
+          method: 'POST'
         }
-      )["PasswordPolicy"]
+      )['PasswordPolicy']
     end
     if @resp.nil?
-      @ram_id = "empty response"
+      @ram_id = 'empty response'
       return
     end
 
     @ram_info                     = @resp
-    @hard_expiry                  = @ram_info["HardExpiry"]
-    @max_login_attempts           = @ram_info["MaxLoginAttemps"]
-    @max_password_age             = @ram_info["MaxPasswordAge"]
-    @minimum_password_length      = @ram_info["MinimumPasswordLength"]
-    @password_reuse_prevention    = @ram_info["PasswordReusePrevention"]
-    @require_lowercase_characters = @ram_info["RequireLowercaseCharacters"]
-    @require_numbers              = @ram_info["RequireNumbers"]
-    @require_symbols              = @ram_info["RequireSymbols"]
-    @require_uppercase_characters = @ram_info["RequireUppercaseCharacters"]
+    @hard_expiry                  = @ram_info['HardExpiry']
+    @max_login_attempts           = @ram_info['MaxLoginAttemps']
+    @max_password_age             = @ram_info['MaxPasswordAge']
+    @minimum_password_length      = @ram_info['MinimumPasswordLength']
+    @password_reuse_prevention    = @ram_info['PasswordReusePrevention']
+    @require_lowercase_characters = @ram_info['RequireLowercaseCharacters']
+    @require_numbers              = @ram_info['RequireNumbers']
+    @require_symbols              = @ram_info['RequireSymbols']
+    @require_uppercase_characters = @ram_info['RequireUppercaseCharacters']
   end
 
   def exists?
     !@ram_info.nil?
   end
 
+  def resource_id
+    "alicloud_ram_password_policy_#{@opts[:region]}"
+  end
+
   def to_s
-    "AliCloud RAM Password Policy"
+    'AliCloud RAM Password Policy'
   end
 end

--- a/libraries/alicloud_ram_policies.rb
+++ b/libraries/alicloud_ram_policies.rb
@@ -25,7 +25,7 @@ class AliCloudRamPolicies < AliCloudResourceBase
   def initialize(opts = {})
     opts = { type: opts } if opts.is_a?(String)
     super(opts)
-    validate_parameters(allow: %i[only_attached type], required: %i[region])
+    validate_parameters(allow: %i(only_attached type), required: %i(region))
 
     @type = opts[:type]
     opts[:type] = 'System' unless opts[:type]
@@ -80,8 +80,8 @@ class AliCloudRamPolicies < AliCloudResourceBase
         action: 'ListPolicies',
         params: filters,
         opts: {
-          method: 'POST'
-        }
+          method: 'POST',
+        },
       )
       return resp
     end
@@ -95,8 +95,8 @@ class AliCloudRamPolicies < AliCloudResourceBase
         action: 'ListEntitiesForPolicy',
         params: filters,
         opts: {
-          method: 'POST'
-        }
+          method: 'POST',
+        },
       )
       return resp
     end

--- a/libraries/alicloud_ram_policies.rb
+++ b/libraries/alicloud_ram_policies.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "alicloud_backend"
+require 'alicloud_backend'
 
 class AliCloudRamPolicies < AliCloudResourceBase
-  name "alicloud_ram_policies"
-  desc "Verifies settings for a collection of AliCloud RAM Policies"
+  name 'alicloud_ram_policies'
+  desc 'Verifies settings for a collection of AliCloud RAM Policies'
   example '
     describe alicloud_ram_policies do
       it { should exist }
@@ -14,25 +14,25 @@ class AliCloudRamPolicies < AliCloudResourceBase
   attr_reader :table
 
   FilterTable.create
-    .register_column(:policy_names,      field: :policy_name)
-    .register_column(:default_versions,  field: :default_version)
-    .register_column(:attachment_counts, field: :attachment_count)
-    .register_column(:attached_groups,   field: :attached_groups)
-    .register_column(:attached_roles,    field: :attached_roles)
-    .register_column(:attached_users,    field: :attached_users)
-    .install_filter_methods_on_resource(self, :table)
+             .register_column(:policy_names,      field: :policy_name)
+             .register_column(:default_versions,  field: :default_version)
+             .register_column(:attachment_counts, field: :attachment_count)
+             .register_column(:attached_groups,   field: :attached_groups)
+             .register_column(:attached_roles,    field: :attached_roles)
+             .register_column(:attached_users,    field: :attached_users)
+             .install_filter_methods_on_resource(self, :table)
 
   def initialize(opts = {})
     opts = { type: opts } if opts.is_a?(String)
     super(opts)
-    validate_parameters(allow: %i{only_attached type}, required: %i{region})
+    validate_parameters(allow: %i[only_attached type], required: %i[region])
 
     @type = opts[:type]
-    opts[:type] = "System" unless opts[:type]
+    opts[:type] = 'System' unless opts[:type]
     @table = fetch_data(opts)
     return unless @type.nil?
 
-    opts[:type] = "Custom"
+    opts[:type] = 'Custom'
     @table += fetch_data(opts)
   end
 
@@ -43,29 +43,29 @@ class AliCloudRamPolicies < AliCloudResourceBase
       response = list_policies(opts)
       return [] if !response || response.empty?
 
-      response["Policies"]["Policy"].map do |policy|
-        unless opts[:only_attached] && policy["AttachmentCount"] == 0
-          row = { policy_name:      policy["PolicyName"],
-                  default_version:  policy["DefaultVersion"],
-                  attachment_count: policy["AttachmentCount"] }
+      response['Policies']['Policy'].map do |policy|
+        next if opts[:only_attached] && (policy['AttachmentCount']).zero?
 
-          if policy["AttachmentCount"] > 0
-            attached_entities = get_attached_entities(opts.merge({ policy_name: policy["PolicyName"] }))
-            row[:attached_groups] = attached_entities["Groups"]["Group"].map { |x| x["GroupName"] }
-            row[:attached_roles] = attached_entities["Roles"]["Role"].map { |x| x["RoleName"] }
-            row[:attached_users] = attached_entities["Users"]["User"].map { |x| x["UserName"] }
-          else
-            row[:attached_groups] = []
-            row[:attached_roles] = []
-            row[:attached_users] = []
-          end
-          ram_policy_rows += [ row ]
+        row = { policy_name: policy['PolicyName'],
+                default_version: policy['DefaultVersion'],
+                attachment_count: policy['AttachmentCount'] }
+
+        if (policy['AttachmentCount']).positive?
+          attached_entities = get_attached_entities(opts.merge({ policy_name: policy['PolicyName'] }))
+          row[:attached_groups] = attached_entities['Groups']['Group'].map { |x| x['GroupName'] }
+          row[:attached_roles] = attached_entities['Roles']['Role'].map { |x| x['RoleName'] }
+          row[:attached_users] = attached_entities['Users']['User'].map { |x| x['UserName'] }
+        else
+          row[:attached_groups] = []
+          row[:attached_roles] = []
+          row[:attached_users] = []
         end
+        ram_policy_rows += [row]
       end
 
-      break unless response["IsTruncated"]
+      break unless response['IsTruncated']
 
-      opts[:marker] = response["Marker"]
+      opts[:marker] = response['Marker']
     end
     opts.delete(:marker)
     ram_policy_rows
@@ -73,14 +73,14 @@ class AliCloudRamPolicies < AliCloudResourceBase
 
   def list_policies(opts)
     filters = { RegionId: opts[:region] }
-    filters["PolicyType"] = opts[:type]
-    filters["Marker"] = opts[:marker] if opts[:marker]
+    filters['PolicyType'] = opts[:type]
+    filters['Marker'] = opts[:marker] if opts[:marker]
     catch_alicloud_errors do
       resp = @alicloud.ram_client.request(
-        action: "ListPolicies",
+        action: 'ListPolicies',
         params: filters,
         opts: {
-          method: "POST",
+          method: 'POST'
         }
       )
       return resp
@@ -89,13 +89,13 @@ class AliCloudRamPolicies < AliCloudResourceBase
 
   def get_attached_entities(opts)
     filters = { RegionId: opts[:region], PolicyName: opts[:policy_name] }
-    filters["PolicyType"] = opts[:type] || "System"
+    filters['PolicyType'] = opts[:type] || 'System'
     catch_alicloud_errors do
       resp = @alicloud.ram_client.request(
-        action: "ListEntitiesForPolicy",
+        action: 'ListEntitiesForPolicy',
         params: filters,
         opts: {
-          method: "POST",
+          method: 'POST'
         }
       )
       return resp
@@ -107,6 +107,6 @@ class AliCloudRamPolicies < AliCloudResourceBase
   end
 
   def to_s
-    "AliCloud RAM Policies (#{@type.nil? ? "All" : @type})"
+    "AliCloud RAM Policies (#{@type.nil? ? 'All' : @type})"
   end
 end

--- a/libraries/alicloud_ram_policy.rb
+++ b/libraries/alicloud_ram_policy.rb
@@ -26,7 +26,7 @@ class AliCloudRamPolicy < AliCloudResourceBase
   def initialize(opts = {})
     opts = { policy_name: opts } if opts.is_a?(String)
     super(opts)
-    validate_parameters(required: %i[policy_name region], allow: %i[type])
+    validate_parameters(required: %i(policy_name region), allow: %i(type))
     @opts = opts
 
     if opts[:type]
@@ -69,8 +69,8 @@ class AliCloudRamPolicy < AliCloudResourceBase
         action: 'GetPolicy',
         params: filters,
         opts: {
-          method: 'POST'
-        }
+          method: 'POST',
+        },
       )
 
       return resp
@@ -91,7 +91,7 @@ class AliCloudRamPolicy < AliCloudResourceBase
     criteria = criteria.each_with_object({}) { |(k, v), h| h[k.downcase.to_sym] = v.is_a?(Array) ? v : [v] }
     return false if criteria.empty? || statements.empty?
 
-    allowed_statement_elements = %i[Action Effect Sid Resource NotAction NotResource]
+    allowed_statement_elements = %i(Action Effect Sid Resource NotAction NotResource)
     # downcase keys to eliminate formatting issue
     unless criteria.keys.all? { |k| allowed_statement_elements.map(&:downcase).include?(k) }
       raise ArgumentError,
@@ -122,11 +122,11 @@ class AliCloudRamPolicy < AliCloudResourceBase
         params: {
           RegionId: opts[:region],
           PolicyName: opts[:policy_name],
-          PolicyType: policy_type
+          PolicyType: policy_type,
         },
         opts: {
-          method: 'POST'
-        }
+          method: 'POST',
+        },
       )
       return resp
     end

--- a/libraries/alicloud_ram_user.rb
+++ b/libraries/alicloud_ram_user.rb
@@ -21,7 +21,7 @@ class AliCloudRamUser < AliCloudResourceBase
     opts = { user_name: opts } if opts.is_a?(String)
     super(opts)
     @opts = opts
-    validate_parameters(required: %i[user_name region])
+    validate_parameters(required: %i(user_name region))
 
     @resp = fetch_user_info(opts)
     return if @resp.nil?
@@ -72,11 +72,11 @@ class AliCloudRamUser < AliCloudResourceBase
         action: 'GetUser',
         params: {
           'RegionId': opts[:region],
-          'UserName': opts[:user_name]
+          'UserName': opts[:user_name],
         },
         opts: {
-          method: 'POST'
-        }
+          method: 'POST',
+        },
       )['User']
       return resp
     end
@@ -88,11 +88,11 @@ class AliCloudRamUser < AliCloudResourceBase
         action: 'GetLoginProfile',
         params: {
           'RegionId': opts[:region],
-          'UserName': opts[:user_name]
+          'UserName': opts[:user_name],
         },
         opts: {
-          method: 'POST'
-        }
+          method: 'POST',
+        },
       )['LoginProfile']
       return resp
     end
@@ -104,11 +104,11 @@ class AliCloudRamUser < AliCloudResourceBase
         action: 'ListAccessKeys',
         params: {
           'RegionId': opts[:region],
-          'UserName': opts[:user_name]
+          'UserName': opts[:user_name],
         },
         opts: {
-          method: 'POST'
-        }
+          method: 'POST',
+        },
       )['AccessKeys']['AccessKey']
       return resp
     end

--- a/libraries/alicloud_ram_user_mfa.rb
+++ b/libraries/alicloud_ram_user_mfa.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require "alicloud_backend"
+require 'alicloud_backend'
 
 class AliCloudRamUserMFA < AliCloudResourceBase
-  name "alicloud_ram_user_mfa"
+  name 'alicloud_ram_user_mfa'
   desc "Verifies settings for users' MFA"
 
   example '
@@ -18,38 +18,42 @@ class AliCloudRamUserMFA < AliCloudResourceBase
   def initialize(opts = {})
     opts = { user_name: opts } if opts.is_a?(String)
     super(opts)
-    validate_parameters(required: %i{user_name region})
+    validate_parameters(required: %i[user_name region])
     @user_name = opts[:user_name]
 
     @resp = fetch_mfa_info(opts)
     if @resp.nil?
-      @serial_number = "empty response"
+      @serial_number = 'empty response'
       return
     end
 
     @mfa           = @resp
-    @serial_number = @mfa["SerialNumber"]
-    @type          = @mfa["Type"]
+    @serial_number = @mfa['SerialNumber']
+    @type          = @mfa['Type']
   end
 
   def fetch_mfa_info(opts)
-    catch_alicloud_errors(ignore: "EntityNotExist.User.MFADevice") do
+    catch_alicloud_errors(ignore: 'EntityNotExist.User.MFADevice') do
       resp = @alicloud.ram_client.request(
-        action: "GetUserMFAInfo",
+        action: 'GetUserMFAInfo',
         params: {
           'RegionId': opts[:region],
-          'UserName': opts[:user_name],
+          'UserName': opts[:user_name]
         },
         opts: {
-          method: "POST",
+          method: 'POST'
         }
-      )["MFADevice"]
+      )['MFADevice']
       return resp
     end
   end
 
   def exists?
     !@mfa.nil?
+  end
+
+  def resource_id
+    "#{@user_id || @user_name}_#{@serial_number}"
   end
 
   def to_s

--- a/libraries/alicloud_ram_user_mfa.rb
+++ b/libraries/alicloud_ram_user_mfa.rb
@@ -18,7 +18,7 @@ class AliCloudRamUserMFA < AliCloudResourceBase
   def initialize(opts = {})
     opts = { user_name: opts } if opts.is_a?(String)
     super(opts)
-    validate_parameters(required: %i[user_name region])
+    validate_parameters(required: %i(user_name region))
     @user_name = opts[:user_name]
 
     @resp = fetch_mfa_info(opts)
@@ -38,11 +38,11 @@ class AliCloudRamUserMFA < AliCloudResourceBase
         action: 'GetUserMFAInfo',
         params: {
           'RegionId': opts[:region],
-          'UserName': opts[:user_name]
+          'UserName': opts[:user_name],
         },
         opts: {
-          method: 'POST'
-        }
+          method: 'POST',
+        },
       )['MFADevice']
       return resp
     end

--- a/libraries/alicloud_ram_users.rb
+++ b/libraries/alicloud_ram_users.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "alicloud_backend"
+require 'alicloud_backend'
 
 class AliCloudRamUsers < AliCloudResourceBase
-  name "alicloud_ram_users"
-  desc "Verifies settings for AliCloud ram users"
+  name 'alicloud_ram_users'
+  desc 'Verifies settings for AliCloud ram users'
 
   example "
     # ensure there's more than 1 users
@@ -17,80 +17,92 @@ class AliCloudRamUsers < AliCloudResourceBase
 
   # FilterTable setup
   FilterTable.create
-    .register_column(:update_dates, field: :update_date)
-    .register_column(:user_names, field: :user_name)
-    .register_column(:user_ids, field: :user_id)
-    .register_column(:comments_s, field: :comments)
-    .register_column(:display_names, field: :display_name)
-    .register_column(:create_dates, field: :create_date)
-    .register_column(:has_console_access, field: :has_console_access)
-    .register_column(:access_keys, field: :access_keys)
-    .register_column(:has_access_key, field: :has_access_key)
-    .register_column(:active_access_keys, field: :active_access_keys)
-    .register_column(:has_active_access_key, field: :has_active_access_key)
-    .register_column(:has_console_and_key_access, field: :has_console_and_key_access)
-    .register_column(:has_mfa_enabled, field: :has_mfa_enabled)
-    .install_filter_methods_on_resource(self, :table)
+             .register_column(:update_dates, field: :update_date)
+             .register_column(:user_names, field: :user_name)
+             .register_column(:user_ids, field: :user_id)
+             .register_column(:comments_s, field: :comments)
+             .register_column(:display_names, field: :display_name)
+             .register_column(:create_dates, field: :create_date)
+             .register_column(:has_console_access, field: :has_console_access)
+             .register_column(:access_keys, field: :access_keys)
+             .register_column(:has_access_key, field: :has_access_key)
+             .register_column(:active_access_keys, field: :active_access_keys)
+             .register_column(:has_active_access_key, field: :has_active_access_key)
+             .register_column(:has_console_and_key_access, field: :has_console_and_key_access)
+             .register_column(:has_mfa_enabled, field: :has_mfa_enabled)
+             .install_filter_methods_on_resource(self, :table)
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters(required: %i{region})
+    validate_parameters(required: %i[region])
 
     @users = fetch_users(opt[:region])
     return [] if !@users || @users.empty?
 
     user_rows = []
     @users.map do |user|
-      user_name = user["UserName"]
+      user_name = user['UserName']
 
       login_profile = fetch_login_profile(opts[:region], user_name)
       access_keys = fetch_access_keys(opts[:region], user_name)
-      active_access_keys = access_keys.nil? ? [] : access_keys.select { |x| x["Status"] == "Active" }.map { |x| x["AccessKeyId"] }
+      active_access_keys = if access_keys.nil?
+                             []
+                           else
+                             access_keys.select do |x|
+                               x['Status'] == 'Active'
+                             end.map { |x| x['AccessKeyId'] }
+                           end
       mfa = fetch_user_mfa(opts[:region], user_name)
 
       user_rows += [{
-        update_date: user["UpdateDate"],
+        update_date: user['UpdateDate'],
         user_name: user_name,
-        user_id: user["UserId"],
-        comments: user["Comments"],
-        display_name: user["DisplayName"],
-        create_date: user["CreateDate"],
+        user_id: user['UserId'],
+        comments: user['Comments'],
+        display_name: user['DisplayName'],
+        create_date: user['CreateDate'],
         has_console_access: login_profile.nil? ? false : true,
-        access_keys: access_keys.nil? ? [] : access_keys.map { |x| x["AccessKeyId"] },
+        access_keys: access_keys.nil? ? [] : access_keys.map { |x| x['AccessKeyId'] },
         has_access_key: access_keys.nil? ? false : true,
-        active_access_keys: access_keys.nil? ? [] : access_keys.select { |x| x["Status"] == "Active" }.map { |x| x["AccessKeyId"] },
-        has_active_access_key: active_access_keys.count > 0 ? true : false,
-        has_console_and_key_access: !login_profile.nil? && active_access_keys.count > 0,
-        has_mfa_enabled: mfa.nil? ? false : true,
+        active_access_keys: if access_keys.nil?
+                              []
+                            else
+                              access_keys.select do |x|
+                                x['Status'] == 'Active'
+                              end.map { |x| x['AccessKeyId'] }
+                            end,
+        has_active_access_key: active_access_keys.count.positive? ? true : false,
+        has_console_and_key_access: !login_profile.nil? && active_access_keys.count.positive?,
+        has_mfa_enabled: mfa.nil? ? false : true
       }]
     end
     @table = user_rows
   end
 
-  def fetch_users(region)
+  def fetch_users(_region)
     catch_alicloud_errors do
       resp = @alicloud.ram_client.request(
-        action: "ListUsers",
+        action: 'ListUsers',
         params: {
-          'RegionId': opts[:region],
+          'RegionId': opts[:region]
         }
-      )["Users"]["User"]
+      )['Users']['User']
       return resp
     end
   end
 
   def fetch_login_profile(region, user)
-    catch_alicloud_errors("EntityNotExist.User.LoginProfile") do
+    catch_alicloud_errors('EntityNotExist.User.LoginProfile') do
       resp = @alicloud.ram_client.request(
-        action: "GetLoginProfile",
+        action: 'GetLoginProfile',
         params: {
           'RegionId': region,
-          'UserName': user,
+          'UserName': user
         },
         opts: {
-          method: "POST",
+          method: 'POST'
         }
-      )["LoginProfile"]
+      )['LoginProfile']
       return resp
     end
   end
@@ -98,31 +110,31 @@ class AliCloudRamUsers < AliCloudResourceBase
   def fetch_access_keys(region, user)
     catch_alicloud_errors do
       resp = @alicloud.ram_client.request(
-        action: "ListAccessKeys",
+        action: 'ListAccessKeys',
         params: {
           'RegionId': region,
-          'UserName': user,
+          'UserName': user
         },
         opts: {
-          method: "POST",
+          method: 'POST'
         }
-      )["AccessKeys"]["AccessKey"]
+      )['AccessKeys']['AccessKey']
       return resp
     end
   end
 
   def fetch_user_mfa(region, user)
-    catch_alicloud_errors("EntityNotExist.User.MFADevice") do
+    catch_alicloud_errors('EntityNotExist.User.MFADevice') do
       resp = @alicloud.ram_client.request(
-        action: "GetUserMFAInfo",
+        action: 'GetUserMFAInfo',
         params: {
           'RegionId': region,
-          'UserName': user,
+          'UserName': user
         },
         opts: {
-          method: "POST",
+          method: 'POST'
         }
-      )["MFADevice"]
+      )['MFADevice']
       return resp
     end
   end

--- a/libraries/alicloud_ram_users.rb
+++ b/libraries/alicloud_ram_users.rb
@@ -34,7 +34,7 @@ class AliCloudRamUsers < AliCloudResourceBase
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters(required: %i[region])
+    validate_parameters(required: %i(region))
 
     @users = fetch_users(opt[:region])
     return [] if !@users || @users.empty?
@@ -73,7 +73,7 @@ class AliCloudRamUsers < AliCloudResourceBase
                             end,
         has_active_access_key: active_access_keys.count.positive? ? true : false,
         has_console_and_key_access: !login_profile.nil? && active_access_keys.count.positive?,
-        has_mfa_enabled: mfa.nil? ? false : true
+        has_mfa_enabled: mfa.nil? ? false : true,
       }]
     end
     @table = user_rows
@@ -84,8 +84,8 @@ class AliCloudRamUsers < AliCloudResourceBase
       resp = @alicloud.ram_client.request(
         action: 'ListUsers',
         params: {
-          'RegionId': opts[:region]
-        }
+          'RegionId': opts[:region],
+        },
       )['Users']['User']
       return resp
     end
@@ -97,11 +97,11 @@ class AliCloudRamUsers < AliCloudResourceBase
         action: 'GetLoginProfile',
         params: {
           'RegionId': region,
-          'UserName': user
+          'UserName': user,
         },
         opts: {
-          method: 'POST'
-        }
+          method: 'POST',
+        },
       )['LoginProfile']
       return resp
     end
@@ -113,11 +113,11 @@ class AliCloudRamUsers < AliCloudResourceBase
         action: 'ListAccessKeys',
         params: {
           'RegionId': region,
-          'UserName': user
+          'UserName': user,
         },
         opts: {
-          method: 'POST'
-        }
+          method: 'POST',
+        },
       )['AccessKeys']['AccessKey']
       return resp
     end
@@ -129,11 +129,11 @@ class AliCloudRamUsers < AliCloudResourceBase
         action: 'GetUserMFAInfo',
         params: {
           'RegionId': region,
-          'UserName': user
+          'UserName': user,
         },
         opts: {
-          method: 'POST'
-        }
+          method: 'POST',
+        },
       )['MFADevice']
       return resp
     end

--- a/libraries/alicloud_rd.rb
+++ b/libraries/alicloud_rd.rb
@@ -16,14 +16,14 @@ class AliCloudResourceDirectory < AliCloudResourceBase
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters(required: %i[region])
+    validate_parameters(required: %i(region))
 
     catch_alicloud_errors do
       @resp = @alicloud.rm_client.request(
         action: 'GetResourceDirectory',
         params: {
-          "RegionId": opts[:region]
-        }
+          "RegionId": opts[:region],
+        },
       )
     end
 

--- a/libraries/alicloud_rd.rb
+++ b/libraries/alicloud_rd.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "alicloud_backend"
+require 'alicloud_backend'
 
 class AliCloudResourceDirectory < AliCloudResourceBase
-  name "alicloud_resource_directory"
-  desc "Verifies settings for AliCloud resource management"
+  name 'alicloud_resource_directory'
+  desc 'Verifies settings for AliCloud resource management'
   example "
   describe alicloud_resource_directory do
     it { should exist}
@@ -16,31 +16,35 @@ class AliCloudResourceDirectory < AliCloudResourceBase
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters(required: %i{region})
+    validate_parameters(required: %i[region])
 
     catch_alicloud_errors do
       @resp = @alicloud.rm_client.request(
-        action: "GetResourceDirectory",
+        action: 'GetResourceDirectory',
         params: {
-          "RegionId": opts[:region],
+          "RegionId": opts[:region]
         }
       )
     end
 
-    if @resp.nil? || @resp["ResourceDirectory"].nil?
+    if @resp.nil? || @resp['ResourceDirectory'].nil?
       @resource_directory_id = nil
       @master_account_name = nil
       @master_account_id = nil
       return
     end
 
-    @resource_directory_id = @resp["ResourceDirectory"]["ResourceDirectoryId"]
-    @master_account_name = @resp["ResourceDirectory"]["MasterAccountName"]
-    @master_account_id = @resp["ResourceDirectory"]["MasterAccountId"]
+    @resource_directory_id = @resp['ResourceDirectory']['ResourceDirectoryId']
+    @master_account_name = @resp['ResourceDirectory']['MasterAccountName']
+    @master_account_id = @resp['ResourceDirectory']['MasterAccountId']
   end
 
   def exists?
     !@resp.nil?
+  end
+
+  def resource_id
+    "#{@resource_directory_id}_#{@opts[:region]}"
   end
 
   def to_s

--- a/libraries/alicloud_region.rb
+++ b/libraries/alicloud_region.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "alicloud_backend"
+require 'alicloud_backend'
 
 class AliCloudRegion < AliCloudResourceBase
-  name "alicloud_region"
-  desc "Verifies settings for an AliCloud region"
+  name 'alicloud_region'
+  desc 'Verifies settings for an AliCloud region'
 
   example "
     describe alicloud_region('eu-west-1') do
@@ -17,21 +17,25 @@ class AliCloudRegion < AliCloudResourceBase
     opts = { region_name: opts } if opts.is_a?(String)
 
     super(opts)
-    validate_parameters(required: %i{region_name region})
+    validate_parameters(required: %i[region_name region])
 
     @region_name = opts[:region_name]
     catch_alicloud_errors do
-      @regions = @alicloud.ecs_client.request(action: "DescribeRegions")["Regions"]["Region"]
-      resp = @regions.find { |r| r["RegionId"] == @region_name }
+      @regions = @alicloud.ecs_client.request(action: 'DescribeRegions')['Regions']['Region']
+      resp = @regions.find { |r| r['RegionId'] == @region_name }
       return if resp.nil?
 
-      @endpoint = resp["RegionEndpoint"]
-      @region_local_name = resp["LocalName"]
+      @endpoint = resp['RegionEndpoint']
+      @region_local_name = resp['LocalName']
     end
   end
 
   def exists?
     !@endpoint.nil?
+  end
+
+  def resource_id
+    @region_name
   end
 
   def to_s

--- a/libraries/alicloud_region.rb
+++ b/libraries/alicloud_region.rb
@@ -17,7 +17,7 @@ class AliCloudRegion < AliCloudResourceBase
     opts = { region_name: opts } if opts.is_a?(String)
 
     super(opts)
-    validate_parameters(required: %i[region_name region])
+    validate_parameters(required: %i(region_name region))
 
     @region_name = opts[:region_name]
     catch_alicloud_errors do

--- a/libraries/alicloud_regions.rb
+++ b/libraries/alicloud_regions.rb
@@ -22,7 +22,7 @@ class AliCloudRegions < AliCloudResourceBase
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters(required: %i[region])
+    validate_parameters(required: %i(region))
     @table = fetch_data
   end
 

--- a/libraries/alicloud_regions.rb
+++ b/libraries/alicloud_regions.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "alicloud_backend"
+require 'alicloud_backend'
 
 class AliCloudRegions < AliCloudResourceBase
-  name "alicloud_regions"
-  desc "Verifies settings for AliCloud Regions in bulk"
+  name 'alicloud_regions'
+  desc 'Verifies settings for AliCloud Regions in bulk'
 
   example '
     describe alicloud_regions do
@@ -15,28 +15,28 @@ class AliCloudRegions < AliCloudResourceBase
   attr_reader :table
 
   FilterTable.create
-    .register_column(:region_names,       field: :region_name)
-    .register_column(:endpoints,          field: :endpoint)
-    .register_column(:region_local_names, field: :region_local_name)
-    .install_filter_methods_on_resource(self, :table)
+             .register_column(:region_names,       field: :region_name)
+             .register_column(:endpoints,          field: :endpoint)
+             .register_column(:region_local_names, field: :region_local_name)
+             .install_filter_methods_on_resource(self, :table)
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters(required: %i{region})
+    validate_parameters(required: %i[region])
     @table = fetch_data
   end
 
   def fetch_data
     region_rows = []
     catch_alicloud_errors do
-      @regions = @alicloud.ecs_client.request(action: "DescribeRegions")["Regions"]["Region"]
+      @regions = @alicloud.ecs_client.request(action: 'DescribeRegions')['Regions']['Region']
     end
     return [] if !@regions || @regions.empty?
 
     @regions.each do |region|
-      region_rows += [{ region_name: region["RegionId"],
-                        endpoint: region["RegionEndpoint"],
-                        region_local_name: region["LocalName"] }]
+      region_rows += [{ region_name: region['RegionId'],
+                        endpoint: region['RegionEndpoint'],
+                        region_local_name: region['LocalName'] }]
     end
     @table = region_rows
   end

--- a/libraries/alicloud_security_group.rb
+++ b/libraries/alicloud_security_group.rb
@@ -1,31 +1,32 @@
 # frozen_string_literal: true
 
-require "alicloud_backend"
+require 'alicloud_backend'
 
 class AliCloudSecurityGroup < AliCloudResourceBase
-  name "alicloud_security_group"
-  desc "Verifies settings for an individual AliCloud Security Group"
+  name 'alicloud_security_group'
+  desc 'Verifies settings for an individual AliCloud Security Group'
   example "
   describe alicloud_security_group('sg-12345678') do
     it { should exist }
     it { should_not allow_in(port: 443, ipv4_range: '0.0.0.0/0')}
   end
   "
-  attr_reader :description, :group_id, :group_name, :vpc_id, :inbound_rules, :outbound_rules, :inbound_rules_count, :outbound_rules_count
+  attr_reader :description, :group_id, :group_name, :vpc_id, :inbound_rules, :outbound_rules, :inbound_rules_count,
+              :outbound_rules_count
 
   def initialize(opts = {})
     opts = { group_id: opts } if opts.is_a?(String)
     opts[:group_id] = opts.delete(:id) if opts.key?(:id) # id is an alias for group_id
     @opts = opts
     super(opts)
-    validate_parameters(required: %i{group_id region})
+    validate_parameters(required: %i[group_id region])
 
-    catch_alicloud_errors(ignore: "InvalidSecurityGroupId.NotFound") do
+    catch_alicloud_errors(ignore: 'InvalidSecurityGroupId.NotFound') do
       @resp = @alicloud.ecs_client.request(
-        action: "DescribeSecurityGroupAttribute",
+        action: 'DescribeSecurityGroupAttribute',
         params: {
           "RegionId": opts[:region],
-          "SecurityGroupId": opts[:group_id],
+          "SecurityGroupId": opts[:group_id]
         }
       )
     end
@@ -33,44 +34,43 @@ class AliCloudSecurityGroup < AliCloudResourceBase
     if @resp.nil?
       @inbound_rules = []
       @outbound_rules = []
-      @group_id = "empty response"
+      @group_id = 'empty response'
       return
     end
 
     @security_group = @resp
-    @group_id       = @security_group["SecurityGroupId"]
-    @vpc_id         = @security_group["VpcId"]
-    @description    = @security_group["Description"]
-    @group_name     = @security_group["SecurityGroupName"]
-    @inbound_rules  = @security_group["Permissions"]["Permission"].select { |r| r["Direction"] == "ingress" }
-    @outbound_rules = @security_group["Permissions"]["Permission"].select { |r| r["Direction"] == "egress" }
+    @group_id       = @security_group['SecurityGroupId']
+    @vpc_id         = @security_group['VpcId']
+    @description    = @security_group['Description']
+    @group_name     = @security_group['SecurityGroupName']
+    @inbound_rules  = @security_group['Permissions']['Permission'].select { |r| r['Direction'] == 'ingress' }
+    @outbound_rules = @security_group['Permissions']['Permission'].select { |r| r['Direction'] == 'egress' }
 
     @inbound_rules_count = @inbound_rules.count
     @outbound_rules_count = @outbound_rules.count
   end
 
   def allow_in?(criteria = {})
-    return false unless (@inbound_rules.count > 0) && criteria.key?(:ipv4_range)
+    return false unless @inbound_rules.count.positive? && criteria.key?(:ipv4_range)
 
     # Port is an optional parameter so we can write controls against CIDR masks only
     port = criteria[:port] unless criteria[:port].nil?
     ipv4_range = criteria[:ipv4_range]
     @inbound_rules.each do |rule|
-
       # If our rule has a securitygroup ID instead of a CIDR mask as the auth object, skip it...
-      next if rule["SourceCidrIp"].empty? && !rule["SourceGroupId"].empty?
+      next if rule['SourceCidrIp'].empty? && !rule['SourceGroupId'].empty?
 
-      policy = rule["Policy"]
-      next unless policy == "Accept"
+      policy = rule['Policy']
+      next unless policy == 'Accept'
 
-      cidr = IPAddr.new(rule["SourceCidrIp"])
+      cidr = IPAddr.new(rule['SourceCidrIp'])
       next unless cidr.include?(IPAddr.new(ipv4_range))
 
       # This block is conditional on 'port' having been passed in, otherwise we only care about the previous two checks
       if port.nil?
         return true
       else
-        port_start, port_end = rule["PortRange"].split("/").map(&:to_i)
+        port_start, port_end = rule['PortRange'].split('/').map(&:to_i)
         return true if (port >= port_start) && (port <= port_end)
       end
     end
@@ -83,13 +83,17 @@ class AliCloudSecurityGroup < AliCloudResourceBase
     !@security_group.nil?
   end
 
+  def resource_id
+    @group_id
+  end
+
   def to_s
     if @group_id
       sg = " ID: #{@group_id}"
       sg += " Name: #{@group_name}" if @group_name
       sg += " VPC ID: #{@vpc_id}" if @vpc_id
     else
-      sg = " " + opts[:group_id]
+      sg = " #{opts[:group_id]}"
     end
     opts.key?(:region) ? "ECS Security Group:#{sg} in #{opts[:region]}" : "ECS Security Group#{sg}"
   end

--- a/libraries/alicloud_security_group.rb
+++ b/libraries/alicloud_security_group.rb
@@ -19,15 +19,15 @@ class AliCloudSecurityGroup < AliCloudResourceBase
     opts[:group_id] = opts.delete(:id) if opts.key?(:id) # id is an alias for group_id
     @opts = opts
     super(opts)
-    validate_parameters(required: %i[group_id region])
+    validate_parameters(required: %i(group_id region))
 
     catch_alicloud_errors(ignore: 'InvalidSecurityGroupId.NotFound') do
       @resp = @alicloud.ecs_client.request(
         action: 'DescribeSecurityGroupAttribute',
         params: {
           "RegionId": opts[:region],
-          "SecurityGroupId": opts[:group_id]
-        }
+          "SecurityGroupId": opts[:group_id],
+        },
       )
     end
 

--- a/libraries/alicloud_security_groups.rb
+++ b/libraries/alicloud_security_groups.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "alicloud_backend"
+require 'alicloud_backend'
 
 class AliCloudSecurityGroups < AliCloudResourceBase
-  name "alicloud_security_groups"
-  desc "Verifies settings for AliCloud Security Groups in bulk"
+  name 'alicloud_security_groups'
+  desc 'Verifies settings for AliCloud Security Groups in bulk'
   example "
     # Verify that you have security groups defined
     describe alicloud_security_groups do
@@ -21,15 +21,15 @@ class AliCloudSecurityGroups < AliCloudResourceBase
 
   # FilterTable setup
   FilterTable.create
-    .register_column(:group_ids, field: :group_id)
-    .register_column(:group_descriptions, field: :group_description)
-    .register_column(:vpc_ids, field: :vpc_id)
-    .register_column(:tags, field: :tags)
-    .install_filter_methods_on_resource(self, :table)
+             .register_column(:group_ids, field: :group_id)
+             .register_column(:group_descriptions, field: :group_description)
+             .register_column(:vpc_ids, field: :vpc_id)
+             .register_column(:tags, field: :tags)
+             .install_filter_methods_on_resource(self, :table)
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters(required: %i{region})
+    validate_parameters(required: %i[region])
     @table = fetch_data
   end
 
@@ -38,21 +38,21 @@ class AliCloudSecurityGroups < AliCloudResourceBase
 
     catch_alicloud_errors do
       @security_groups = @alicloud.ecs_client.request(
-        action: "DescribeSecurityGroups",
+        action: 'DescribeSecurityGroups',
         params: {
-          "RegionId": opts[:region],
+          "RegionId": opts[:region]
         }
-      )["SecurityGroups"]["SecurityGroup"]
+      )['SecurityGroups']['SecurityGroup']
     end
 
     return [] if !@security_groups || @security_groups.empty?
 
     @security_groups.map do |security_group|
       security_group_rows += [{
-        group_id: security_group["SecurityGroupId"],
-        group_description: security_group["Description"],
-        vpc_id: security_group["VpcId"],
-        tags: security_group["Tags"]["Tag"],
+        group_id: security_group['SecurityGroupId'],
+        group_description: security_group['Description'],
+        vpc_id: security_group['VpcId'],
+        tags: security_group['Tags']['Tag']
       }]
     end
 

--- a/libraries/alicloud_security_groups.rb
+++ b/libraries/alicloud_security_groups.rb
@@ -29,7 +29,7 @@ class AliCloudSecurityGroups < AliCloudResourceBase
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters(required: %i[region])
+    validate_parameters(required: %i(region))
     @table = fetch_data
   end
 
@@ -40,8 +40,8 @@ class AliCloudSecurityGroups < AliCloudResourceBase
       @security_groups = @alicloud.ecs_client.request(
         action: 'DescribeSecurityGroups',
         params: {
-          "RegionId": opts[:region]
-        }
+          "RegionId": opts[:region],
+        },
       )['SecurityGroups']['SecurityGroup']
     end
 
@@ -52,7 +52,7 @@ class AliCloudSecurityGroups < AliCloudResourceBase
         group_id: security_group['SecurityGroupId'],
         group_description: security_group['Description'],
         vpc_id: security_group['VpcId'],
-        tags: security_group['Tags']['Tag']
+        tags: security_group['Tags']['Tag'],
       }]
     end
 

--- a/libraries/alicloud_slb.rb
+++ b/libraries/alicloud_slb.rb
@@ -21,15 +21,15 @@ class AliCloudSlb < AliCloudResourceBase
     opts[:slb_id] = opts.delete(:id) if opts.key?(:id)
     @opts = opts
     super(opts)
-    validate_parameters(required: %i[slb_id region])
+    validate_parameters(required: %i(slb_id region))
 
     catch_alicloud_errors(ignore: 'InvalidLoadBalancerId.NotFound') do
       @resp = @alicloud.slb_client.request(
         action: 'DescribeLoadBalancerAttribute',
         params: {
           'RegionId': opts[:region],
-          'LoadBalancerId': opts[:slb_id]
-        }
+          'LoadBalancerId': opts[:slb_id],
+        },
       )
     end
 

--- a/libraries/alicloud_slb.rb
+++ b/libraries/alicloud_slb.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "alicloud_backend"
+require 'alicloud_backend'
 
 class AliCloudSlb < AliCloudResourceBase
-  name "alicloud_slb"
-  desc "Verifies properties for an individual AliCloud Application Load Balancer"
+  name 'alicloud_slb'
+  desc 'Verifies properties for an individual AliCloud Application Load Balancer'
   example "
   describe alicloud_slb('slb-123456') do
     it { should exist }
@@ -21,52 +21,52 @@ class AliCloudSlb < AliCloudResourceBase
     opts[:slb_id] = opts.delete(:id) if opts.key?(:id)
     @opts = opts
     super(opts)
-    validate_parameters(required: %i{slb_id region})
+    validate_parameters(required: %i[slb_id region])
 
-    catch_alicloud_errors(ignore: "InvalidLoadBalancerId.NotFound") do
+    catch_alicloud_errors(ignore: 'InvalidLoadBalancerId.NotFound') do
       @resp = @alicloud.slb_client.request(
-        action: "DescribeLoadBalancerAttribute",
+        action: 'DescribeLoadBalancerAttribute',
         params: {
           'RegionId': opts[:region],
-          'LoadBalancerId': opts[:slb_id],
+          'LoadBalancerId': opts[:slb_id]
         }
       )
     end
 
     if @resp.nil?
-      @slb_id = "empty response"
+      @slb_id = 'empty response'
       return
     end
 
     @slb_info                    = @resp
-    @load_balancer_id            = @slb_info["LoadBalancerId"]
-    @load_balancer_name          = @slb_info["LoadBalancerName"]
-    @status                      = @slb_info["LoadBalancerStatus"]
-    @resource_group_id           = @slb_info["ResourceGroupId"]
-    @address                     = @slb_info["Address"]
-    @listener_ports_and_protocol = @slb_info["ListenerPortsAndProtocol"]["ListenerPortAndProtocol"]
-    @backend_servers             = @slb_info["BackendServers"]
-    @has_reserved_info           = @slb_info["HasReservedInfo"]
-    @business_status             = @slb_info["BusinessStatus"]
-    @listener_ports              = @slb_info["ListenerPorts"]
-    @vswitch_id                  = @slb_info["VSwitchId"]
-    @pay_type                    = @slb_info["PayType"]
-    @internet_charge_type        = @slb_info["InternetChargeType"]
-    @vpc_id                      = @slb_info["VpcId"]
-    @delete_protection           = @slb_info["DeleteProtection"]
-    @end_time_stamp              = @slb_info["EndTimeStamp"]
-    @end_time                    = @slb_info["EndTime"]
-    @support_private_ling        = @slb_info["SupportPrivateLink"]
-    @address_ip_version          = @slb_info["AddressIPVersion"]
-    @network_type                = @slb_info["NetworkType"]
-    @bandwidth                   = @slb_info["Bandwidth"]
-    @primary_zone_id             = @slb_info["MasterZoneId"]
-    @create_time                 = @slb_info["CreateTime"]
-    @secondary_zone_id           = @slb_info["SlaveZoneId"]
-    @region_id_alias             = @slb_info["RegionIdAlias"]
-    @region_id                   = @slb_info["RegionId"]
-    @address_type                = @slb_info["AddressType"]
-    @create_time_stamp           = @slb_info["CreateTimeStamp"]
+    @load_balancer_id            = @slb_info['LoadBalancerId']
+    @load_balancer_name          = @slb_info['LoadBalancerName']
+    @status                      = @slb_info['LoadBalancerStatus']
+    @resource_group_id           = @slb_info['ResourceGroupId']
+    @address                     = @slb_info['Address']
+    @listener_ports_and_protocol = @slb_info['ListenerPortsAndProtocol']['ListenerPortAndProtocol']
+    @backend_servers             = @slb_info['BackendServers']
+    @has_reserved_info           = @slb_info['HasReservedInfo']
+    @business_status             = @slb_info['BusinessStatus']
+    @listener_ports              = @slb_info['ListenerPorts']
+    @vswitch_id                  = @slb_info['VSwitchId']
+    @pay_type                    = @slb_info['PayType']
+    @internet_charge_type        = @slb_info['InternetChargeType']
+    @vpc_id                      = @slb_info['VpcId']
+    @delete_protection           = @slb_info['DeleteProtection']
+    @end_time_stamp              = @slb_info['EndTimeStamp']
+    @end_time                    = @slb_info['EndTime']
+    @support_private_ling        = @slb_info['SupportPrivateLink']
+    @address_ip_version          = @slb_info['AddressIPVersion']
+    @network_type                = @slb_info['NetworkType']
+    @bandwidth                   = @slb_info['Bandwidth']
+    @primary_zone_id             = @slb_info['MasterZoneId']
+    @create_time                 = @slb_info['CreateTime']
+    @secondary_zone_id           = @slb_info['SlaveZoneId']
+    @region_id_alias             = @slb_info['RegionIdAlias']
+    @region_id                   = @slb_info['RegionId']
+    @address_type                = @slb_info['AddressType']
+    @create_time_stamp           = @slb_info['CreateTimeStamp']
   end
 
   def exists?
@@ -74,43 +74,47 @@ class AliCloudSlb < AliCloudResourceBase
   end
 
   def https_listeners?
-    !@listener_ports_and_protocol.select { |lpp| lpp["ListenerProtocol"] == "https" }.empty?
+    !@listener_ports_and_protocol.select { |lpp| lpp['ListenerProtocol'] == 'https' }.empty?
   end
 
   def http_listeners?
-    !@listener_ports_and_protocol.select { |lpp| lpp["ListenerProtocol"] == "http" }.empty?
+    !@listener_ports_and_protocol.select { |lpp| lpp['ListenerProtocol'] == 'http' }.empty?
   end
 
   def udp_listeners?
-    !@listener_ports_and_protocol.select { |lpp| lpp["ListenerProtocol"] == "udp" }.empty?
+    !@listener_ports_and_protocol.select { |lpp| lpp['ListenerProtocol'] == 'udp' }.empty?
   end
 
   def tcp_listeners?
-    !@listener_ports_and_protocol.select { |lpp| lpp["ListenerProtocol"] == "tcp" }.empty?
+    !@listener_ports_and_protocol.select { |lpp| lpp['ListenerProtocol'] == 'tcp' }.empty?
   end
 
   def listening_ports
-    @listener_ports_and_protocol.select { |lpp| lpp["ListenerPort"] }
+    @listener_ports_and_protocol.select { |lpp| lpp['ListenerPort'] }
   end
 
   def https_ports
-    @listener_ports_and_protocol.map { |lpp| lpp["ListenerPort"] if lpp["ListenerProtocol"] == "https" }.compact
+    @listener_ports_and_protocol.map { |lpp| lpp['ListenerPort'] if lpp['ListenerProtocol'] == 'https' }.compact
   end
 
   def http_ports
-    @listener_ports_and_protocol.map { |lpp| lpp["ListenerPort"] if lpp["ListenerProtocol"] == "http" }.compact
+    @listener_ports_and_protocol.map { |lpp| lpp['ListenerPort'] if lpp['ListenerProtocol'] == 'http' }.compact
   end
 
   def udp_ports
-    @listener_ports_and_protocol.map { |lpp| lpp["ListenerPort"] if lpp["ListenerProtocol"] == "udp" }.compact
+    @listener_ports_and_protocol.map { |lpp| lpp['ListenerPort'] if lpp['ListenerProtocol'] == 'udp' }.compact
   end
 
   def tcp_ports
-    @listener_ports_and_protocol.map { |lpp| lpp["ListenerPort"] if lpp["ListenerProtocol"] == "tcp" }.compact
+    @listener_ports_and_protocol.map { |lpp| lpp['ListenerPort'] if lpp['ListenerProtocol'] == 'tcp' }.compact
   end
 
   def https_only?
     https_ports.length == listening_ports.length
+  end
+
+  def resource_id
+    @load_balancer_id
   end
 
   def to_s
@@ -118,7 +122,7 @@ class AliCloudSlb < AliCloudResourceBase
       slb = " ID: #{@load_balancer_id}"
       slb += " Name: #{@load_balancer_name}" if @load_balancer_name
     else
-      slb = " " + @opts[:slb_id]
+      slb = " #{@opts[:slb_id]}"
     end
     opts.key?(:region) ? "Server Load Balancer:#{slb} in #{opts[:region]}" : "Server Load Balancer:#{slb}"
   end

--- a/libraries/alicloud_slb_https_listener.rb
+++ b/libraries/alicloud_slb_https_listener.rb
@@ -14,7 +14,7 @@ class AliCloudSlbHttpsListener < AliCloudResourceBase
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters(required: %i[slb_id listener_port region])
+    validate_parameters(required: %i(slb_id listener_port region))
 
     catch_alicloud_errors do
       @resp = @alicloud.slb_client.request(
@@ -22,8 +22,8 @@ class AliCloudSlbHttpsListener < AliCloudResourceBase
         params: {
           'RegionId': opts[:region],
           'LoadBalancerId': opts[:slb_id],
-          'ListenerPort': opts[:listener_port]
-        }
+          'ListenerPort': opts[:listener_port],
+        },
       )
     end
 

--- a/libraries/alicloud_slb_https_listener.rb
+++ b/libraries/alicloud_slb_https_listener.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "alicloud_backend"
+require 'alicloud_backend'
 
 class AliCloudSlbHttpsListener < AliCloudResourceBase
-  name "alicloud_slb_https_listener"
-  desc "Verifies properties for an individual AliCloud Application Load Balancers https listener"
+  name 'alicloud_slb_https_listener'
+  desc 'Verifies properties for an individual AliCloud Application Load Balancers https listener'
   example "
   describe alicloud_slb_https_listener(slb_id: 'slb-123456', listener_port: 443) do
     it { should exist }
@@ -14,15 +14,15 @@ class AliCloudSlbHttpsListener < AliCloudResourceBase
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters(required: %i{slb_id listener_port region})
+    validate_parameters(required: %i[slb_id listener_port region])
 
     catch_alicloud_errors do
       @resp = @alicloud.slb_client.request(
-        action: "DescribeLoadBalancerHTTPSListenerAttribute",
+        action: 'DescribeLoadBalancerHTTPSListenerAttribute',
         params: {
           'RegionId': opts[:region],
           'LoadBalancerId': opts[:slb_id],
-          'ListenerPort': opts[:listener_port],
+          'ListenerPort': opts[:listener_port]
         }
       )
     end
@@ -34,8 +34,12 @@ class AliCloudSlbHttpsListener < AliCloudResourceBase
 
     @listener_info = @resp
     @load_balancer_id = opts[:slb_id]
-    @tls_cipher_policy = @listener_info["TLSCipherPolicy"]
-    @listener_port = @listener_info["ListenerPort"]
+    @tls_cipher_policy = @listener_info['TLSCipherPolicy']
+    @listener_port = @listener_info['ListenerPort']
+  end
+
+  def resource_id
+    @listener_info ? "#{@listener_info['AclId']}_#{@load_balancer_id}" : ''
   end
 
   def exists?
@@ -49,12 +53,9 @@ class AliCloudSlbHttpsListener < AliCloudResourceBase
   end
 
   # This is to make RuboCop happy.
-  def respond_to_missing?(*several_variants)
-    super
-  end
 
   def to_s
-    buf = ""
+    buf = ''
     buf += "Load balancer id: #{@load_balancer_id} " if @load_balancer_id
     buf += "Port: #{@listener_port} " if @listener_port
     opts.key?(:alicloud_region) ? "https_listener: #{buf} in #{opts[:alicloud_region]}" : "https_listener: #{buf}"

--- a/libraries/alicloud_slbs.rb
+++ b/libraries/alicloud_slbs.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "alicloud_backend"
+require 'alicloud_backend'
 
 class AliCloudSlbs < AliCloudResourceBase
-  name "alicloud_slbs"
-  desc "Verifies settings for AliCloud Application Loadbalancers in bulk"
+  name 'alicloud_slbs'
+  desc 'Verifies settings for AliCloud Application Loadbalancers in bulk'
   example "
     # Verify that you have slbs defined
     describe alicloud_slbs do
@@ -20,28 +20,28 @@ class AliCloudSlbs < AliCloudResourceBase
 
   # FilterTable setup
   FilterTable.create
-    .register_column(:created_time_stamps, field: :created_time_stamp)
-    .register_column(:load_balancer_ids, field: :load_balancer_id)
-    .register_column(:load_balancer_names, field: :load_balancer_name)
-    .register_column(:region_id_aliases, field: :region_id_alias)
-    .register_column(:address_ip_versions, field: :address_ip_version)
-    .register_column(:vswitch_ids, field: :vswitch_id)
-    .register_column(:internet_charge_types, field: :internet_charge_type)
-    .register_column(:vpc_ids, field: :vpc_id)
-    .register_column(:secondary_zone_ids, field: :secondary_zone_id)
-    .register_column(:network_types, field: :network_type)
-    .register_column(:main_zone_ids, field: :main_zone_id)
-    .register_column(:create_times, field: :create_time)
-    .register_column(:addresses, field: :address)
-    .register_column(:region_ids, field: :region_id)
-    .register_column(:address_types, field: :address_type)
-    .register_column(:pay_types, field: :pay_type)
-    .register_column(:load_balancer_statuses, field: :load_balancer_status)
-    .install_filter_methods_on_resource(self, :table)
+             .register_column(:created_time_stamps, field: :created_time_stamp)
+             .register_column(:load_balancer_ids, field: :load_balancer_id)
+             .register_column(:load_balancer_names, field: :load_balancer_name)
+             .register_column(:region_id_aliases, field: :region_id_alias)
+             .register_column(:address_ip_versions, field: :address_ip_version)
+             .register_column(:vswitch_ids, field: :vswitch_id)
+             .register_column(:internet_charge_types, field: :internet_charge_type)
+             .register_column(:vpc_ids, field: :vpc_id)
+             .register_column(:secondary_zone_ids, field: :secondary_zone_id)
+             .register_column(:network_types, field: :network_type)
+             .register_column(:main_zone_ids, field: :main_zone_id)
+             .register_column(:create_times, field: :create_time)
+             .register_column(:addresses, field: :address)
+             .register_column(:region_ids, field: :region_id)
+             .register_column(:address_types, field: :address_type)
+             .register_column(:pay_types, field: :pay_type)
+             .register_column(:load_balancer_statuses, field: :load_balancer_status)
+             .install_filter_methods_on_resource(self, :table)
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters(required: %i{region})
+    validate_parameters(required: %i[region])
     @table = fetch_data
   end
 
@@ -50,34 +50,34 @@ class AliCloudSlbs < AliCloudResourceBase
 
     catch_alicloud_errors do
       @load_balancers = @alicloud.slb_client.request(
-        action: "DescribeLoadBalancers",
+        action: 'DescribeLoadBalancers',
         params: {
-          'RegionId': opts[:region],
+          'RegionId': opts[:region]
         }
-      )["LoadBalancers"]["LoadBalancer"]
+      )['LoadBalancers']['LoadBalancer']
     end
 
     return [] if !@load_balancers || @load_balancers.empty?
 
     @load_balancers.map do |load_balancer|
       load_balancer_rows += [{
-        created_time_stamp:   load_balancer["CreateTimeStamp"],
-        load_balancer_id:     load_balancer["LoadBalancerId"],
-        load_balancer_name:   load_balancer["LoadBalancerName"],
-        region_id_alias:      load_balancer["RegionIdAlias"],
-        address_ip_version:   load_balancer["AddressIPVersion"],
-        vswitch_id:           load_balancer["VSwitchId"],
-        internet_charge_type: load_balancer["InternetChargeType"],
-        vpc_id:               load_balancer["VpcId"],
-        secondary_zone_id:    load_balancer["SlaveZoneId"],
-        network_type:         load_balancer["NetworkType"],
-        main_zone_id:         load_balancer["MasterZoneId"],
-        create_time:          load_balancer["CreateTime"],
-        address:              load_balancer["Address"],
-        region_id:            load_balancer["RegionId"],
-        address_type:         load_balancer["AddressType"],
-        pay_type:             load_balancer["PayType"],
-        load_balancer_status: load_balancer["LoadBalancerStatus"],
+        created_time_stamp: load_balancer['CreateTimeStamp'],
+        load_balancer_id: load_balancer['LoadBalancerId'],
+        load_balancer_name: load_balancer['LoadBalancerName'],
+        region_id_alias: load_balancer['RegionIdAlias'],
+        address_ip_version: load_balancer['AddressIPVersion'],
+        vswitch_id: load_balancer['VSwitchId'],
+        internet_charge_type: load_balancer['InternetChargeType'],
+        vpc_id: load_balancer['VpcId'],
+        secondary_zone_id: load_balancer['SlaveZoneId'],
+        network_type: load_balancer['NetworkType'],
+        main_zone_id: load_balancer['MasterZoneId'],
+        create_time: load_balancer['CreateTime'],
+        address: load_balancer['Address'],
+        region_id: load_balancer['RegionId'],
+        address_type: load_balancer['AddressType'],
+        pay_type: load_balancer['PayType'],
+        load_balancer_status: load_balancer['LoadBalancerStatus']
       }]
     end
 
@@ -85,6 +85,6 @@ class AliCloudSlbs < AliCloudResourceBase
   end
 
   def to_s
-    "AliCloud SLBs"
+    'AliCloud SLBs'
   end
 end

--- a/libraries/alicloud_slbs.rb
+++ b/libraries/alicloud_slbs.rb
@@ -41,7 +41,7 @@ class AliCloudSlbs < AliCloudResourceBase
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters(required: %i[region])
+    validate_parameters(required: %i(region))
     @table = fetch_data
   end
 
@@ -52,8 +52,8 @@ class AliCloudSlbs < AliCloudResourceBase
       @load_balancers = @alicloud.slb_client.request(
         action: 'DescribeLoadBalancers',
         params: {
-          'RegionId': opts[:region]
-        }
+          'RegionId': opts[:region],
+        },
       )['LoadBalancers']['LoadBalancer']
     end
 
@@ -77,7 +77,7 @@ class AliCloudSlbs < AliCloudResourceBase
         region_id: load_balancer['RegionId'],
         address_type: load_balancer['AddressType'],
         pay_type: load_balancer['PayType'],
-        load_balancer_status: load_balancer['LoadBalancerStatus']
+        load_balancer_status: load_balancer['LoadBalancerStatus'],
       }]
     end
 

--- a/libraries/alicloud_sts_caller_identity.rb
+++ b/libraries/alicloud_sts_caller_identity.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "alicloud_backend"
+require 'alicloud_backend'
 
 class AliCloudStsCallerIdentity < AliCloudResourceBase
-  name "alicloud_sts_caller_identity"
-  desc "Verifies settings for an AliCloud STS Caller Identity"
+  name 'alicloud_sts_caller_identity'
+  desc 'Verifies settings for an AliCloud STS Caller Identity'
   example '
     describe alicloud_sts_caller_identity do
       its("arn") { should match "acs:ram::.*:user/service-account-inspec" }
@@ -18,8 +18,12 @@ class AliCloudStsCallerIdentity < AliCloudResourceBase
     validate_parameters
 
     catch_alicloud_errors do
-      @arn = @alicloud.sts_client.request(action: "GetCallerIdentity")["Arn"]
+      @arn = @alicloud.sts_client.request(action: 'GetCallerIdentity')['Arn']
     end
+  end
+
+  def resource_id
+    @arn
   end
 
   def exists?
@@ -27,6 +31,6 @@ class AliCloudStsCallerIdentity < AliCloudResourceBase
   end
 
   def to_s
-    "AliCloud Security Token Service Caller Identity"
+    'AliCloud Security Token Service Caller Identity'
   end
 end

--- a/libraries/alicloud_vpc.rb
+++ b/libraries/alicloud_vpc.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "alicloud_backend"
+require 'alicloud_backend'
 
 class AliCloudVpc < AliCloudResourceBase
-  name "alicloud_vpc"
-  desc "Verifies properties for an individual AliCloud Virtual Private Network"
+  name 'alicloud_vpc'
+  desc 'Verifies properties for an individual AliCloud Virtual Private Network'
   example "
   describe alicloud_vpc('vpc-1234567890') do
     it { should exist }
@@ -17,48 +17,52 @@ class AliCloudVpc < AliCloudResourceBase
     opts = { vpc_id: opts } if opts.is_a?(String)
     @opts = opts
     super(opts)
-    validate_parameters(required: %i{vpc_id region})
+    validate_parameters(required: %i[vpc_id region])
 
     catch_alicloud_errors do
       @resp = @alicloud.vpc_client.request(
-        action: "DescribeVpcAttribute",
+        action: 'DescribeVpcAttribute',
         params: {
           'RegionId': opts[:region],
-          'VpcId': opts[:vpc_id],
+          'VpcId': opts[:vpc_id]
         }
       )
     end
 
     # DescribeVpcAttribute will always return a hash with all attributes set to empty string even if the given VpcId is incorrect.
-    if @resp.nil? || @resp["VpcId"].empty?
-      @vpc_id = "empty response"
+    if @resp.nil? || @resp['VpcId'].empty?
+      @vpc_id = 'empty response'
       return
     end
 
     @vpc_info           = @resp
-    @vpc_id             = @vpc_info["VpcId"]
-    @vpc_name           = @vpc_info["VpcName"]
-    @description        = @vpc_info["Description"]
-    @status             = @vpc_info["Status"]
-    @created_time_stamp = @vpc_info["CreationTime"]
-    @is_default         = @vpc_info["IsDefault"]
-    @resource_group_id  = @vpc_info["ResourceGroupId"]
-    @cidr_block         = @vpc_info["CidrBlock"]
-    @ipv6_cidr_block    = @vpc_info["Ipv6CidrBlock"]
-    @vrouter_id         = @vpc_info["VRouterId"]
-    @vswitch_ids        = @vpc_info["VSwitchIds"]["VSwitchId"]
-    @user_cidrs         = @vpc_info["UserCidrs"]["UserCidr"]
+    @vpc_id             = @vpc_info['VpcId']
+    @vpc_name           = @vpc_info['VpcName']
+    @description        = @vpc_info['Description']
+    @status             = @vpc_info['Status']
+    @created_time_stamp = @vpc_info['CreationTime']
+    @is_default         = @vpc_info['IsDefault']
+    @resource_group_id  = @vpc_info['ResourceGroupId']
+    @cidr_block         = @vpc_info['CidrBlock']
+    @ipv6_cidr_block    = @vpc_info['Ipv6CidrBlock']
+    @vrouter_id         = @vpc_info['VRouterId']
+    @vswitch_ids        = @vpc_info['VSwitchIds']['VSwitchId']
+    @user_cidrs         = @vpc_info['UserCidrs']['UserCidr']
     @attached_cens      = []
     # AssociatedCens will only be returned when the VPC is attached to CEN
-    return if @vpc_info["AssociatedCens"].nil?
+    return if @vpc_info['AssociatedCens'].nil?
 
-    @vpc_info["AssociatedCens"]["AssociatedCen"].each do |cen|
-      @attached_cens.append(cen["CenId"])
+    @vpc_info['AssociatedCens']['AssociatedCen'].each do |cen|
+      @attached_cens.append(cen['CenId'])
     end
   end
 
   def exists?
     !@vpc_info.nil?
+  end
+
+  def resource_id
+    @vpc_id
   end
 
   def cen_attached?

--- a/libraries/alicloud_vpc.rb
+++ b/libraries/alicloud_vpc.rb
@@ -17,15 +17,15 @@ class AliCloudVpc < AliCloudResourceBase
     opts = { vpc_id: opts } if opts.is_a?(String)
     @opts = opts
     super(opts)
-    validate_parameters(required: %i[vpc_id region])
+    validate_parameters(required: %i(vpc_id region))
 
     catch_alicloud_errors do
       @resp = @alicloud.vpc_client.request(
         action: 'DescribeVpcAttribute',
         params: {
           'RegionId': opts[:region],
-          'VpcId': opts[:vpc_id]
-        }
+          'VpcId': opts[:vpc_id],
+        },
       )
     end
 

--- a/libraries/alicloud_vpcs.rb
+++ b/libraries/alicloud_vpcs.rb
@@ -35,7 +35,7 @@ class AliCloudVpcs < AliCloudResourceBase
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters(required: %i[region])
+    validate_parameters(required: %i(region))
     @table = fetch_data
   end
 
@@ -46,8 +46,8 @@ class AliCloudVpcs < AliCloudResourceBase
       @vpcs = @alicloud.vpc_client.request(
         action: 'DescribeVpcs',
         params: {
-          'RegionId': opts[:region]
-        }
+          'RegionId': opts[:region],
+        },
       )['Vpcs']['Vpc']
     end
 
@@ -65,7 +65,7 @@ class AliCloudVpcs < AliCloudResourceBase
         resource_group_id: vpc['ResourceGroupId'],
         cidr_block: vpc['CidrBlock'],
         ipv6_cidr_block: vpc['Ipv6CidrBlock'],
-        vrouter_id: vpc['VRouterId']
+        vrouter_id: vpc['VRouterId'],
       }]
     end
 

--- a/libraries/alicloud_vpcs.rb
+++ b/libraries/alicloud_vpcs.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "alicloud_backend"
+require 'alicloud_backend'
 
 class AliCloudVpcs < AliCloudResourceBase
-  name "alicloud_vpcs"
-  desc "Verifies settings for AliCloud Virtual Private Cloud in bulk"
+  name 'alicloud_vpcs'
+  desc 'Verifies settings for AliCloud Virtual Private Cloud in bulk'
   example "
     # Verify that you have vpcs defined
     describe alicloud_vpcs do
@@ -20,22 +20,22 @@ class AliCloudVpcs < AliCloudResourceBase
 
   # FilterTable setup
   FilterTable.create
-    .register_column(:vpc_ids, field: :vpc_id)
-    .register_column(:vpc_names, field: :vpc_name)
-    .register_column(:descriptions, field: :description)
-    .register_column(:statuses, field: :status)
-    .register_column(:created_time_stamps, field: :created_time_stamp)
-    .register_column(:is_defaults, field: :is_default)
-    .register_column(:cen_statuses, field: :cen_status)
-    .register_column(:resource_group_ids, field: :resource_group_id)
-    .register_column(:cidr_blocks, field: :cidr_block)
-    .register_column(:ipv6_cidr_blocks, field: :ipv6_cidr_block)
-    .register_column(:vrouter_ids, field: :vrouter_id)
-    .install_filter_methods_on_resource(self, :table)
+             .register_column(:vpc_ids, field: :vpc_id)
+             .register_column(:vpc_names, field: :vpc_name)
+             .register_column(:descriptions, field: :description)
+             .register_column(:statuses, field: :status)
+             .register_column(:created_time_stamps, field: :created_time_stamp)
+             .register_column(:is_defaults, field: :is_default)
+             .register_column(:cen_statuses, field: :cen_status)
+             .register_column(:resource_group_ids, field: :resource_group_id)
+             .register_column(:cidr_blocks, field: :cidr_block)
+             .register_column(:ipv6_cidr_blocks, field: :ipv6_cidr_block)
+             .register_column(:vrouter_ids, field: :vrouter_id)
+             .install_filter_methods_on_resource(self, :table)
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters(required: %i{region})
+    validate_parameters(required: %i[region])
     @table = fetch_data
   end
 
@@ -44,28 +44,28 @@ class AliCloudVpcs < AliCloudResourceBase
 
     catch_alicloud_errors do
       @vpcs = @alicloud.vpc_client.request(
-        action: "DescribeVpcs",
+        action: 'DescribeVpcs',
         params: {
-          'RegionId': opts[:region],
+          'RegionId': opts[:region]
         }
-      )["Vpcs"]["Vpc"]
+      )['Vpcs']['Vpc']
     end
 
     return [] if !@vpcs || @vpcs.empty?
 
     @vpcs.map do |vpc|
       vpc_rows += [{
-        vpc_id:             vpc["VpcId"],
-        vpc_name:           vpc["VpcName"],
-        description:        vpc["Description"],
-        status:             vpc["Status"],
-        created_time_stamp: vpc["CreationTime"],
-        is_default:         vpc["IsDefault"],
-        cen_status:         vpc["CenStatus"],
-        resource_group_id:  vpc["ResourceGroupId"],
-        cidr_block:         vpc["CidrBlock"],
-        ipv6_cidr_block:    vpc["Ipv6CidrBlock"],
-        vrouter_id:         vpc["VRouterId"],
+        vpc_id: vpc['VpcId'],
+        vpc_name: vpc['VpcName'],
+        description: vpc['Description'],
+        status: vpc['Status'],
+        created_time_stamp: vpc['CreationTime'],
+        is_default: vpc['IsDefault'],
+        cen_status: vpc['CenStatus'],
+        resource_group_id: vpc['ResourceGroupId'],
+        cidr_block: vpc['CidrBlock'],
+        ipv6_cidr_block: vpc['Ipv6CidrBlock'],
+        vrouter_id: vpc['VRouterId']
       }]
     end
 
@@ -73,6 +73,6 @@ class AliCloudVpcs < AliCloudResourceBase
   end
 
   def to_s
-    "AliCloud VPCs"
+    'AliCloud VPCs'
   end
 end

--- a/test/integration/configuration/alicloud_inspec_config.rb
+++ b/test/integration/configuration/alicloud_inspec_config.rb
@@ -100,7 +100,7 @@ module AliCloudInspecConfig
     alicloud_ram_role_name: "test-role-#{add_random_string}",
     alicloud_ram_policy_name: "test-policy-#{add_random_string}",
     alicloud_ram_attached_policy_name_1: "test-attached-policy-#{add_random_string}",
-    alicloud_ram_attached_policy_name_2: "test-attached-policy-#{add_random_string}"
+    alicloud_ram_attached_policy_name_2: "test-attached-policy-#{add_random_string}",
   }
 
   def self.config

--- a/test/integration/configuration/alicloud_inspec_config.rb
+++ b/test/integration/configuration/alicloud_inspec_config.rb
@@ -5,103 +5,102 @@
 # - Inspec expects a YAML attribute file
 # This allows to store all transient parameters in one place.
 # If any of the @config keys are exported as environment variables in uppercase, these take precedence.
-require "json"
-require "yaml"
-require "securerandom"
+require 'json'
+require 'yaml'
+require 'securerandom'
 
 module AliCloudInspecConfig
-
   # helper method for adding random strings
   def self.add_random_string(length = 25)
     (0...length).map { rand(65..90).chr }.join.downcase.to_s
   end
 
-  @alicloud_region = ENV["alicloud_region"] || "eu-west-1"
+  @alicloud_region = ENV['alicloud_region'] || 'eu-west-1'
 
   # Config for terraform / inspec in the below hash
   @config = {
-      # Simple flag to disable creation of resources (useful when prototyping new ones in isolation)
-      alicloud_enable_create: 1,
-      # Generic AliCloud resource parameters
-      alicloud_region: @alicloud_region,
-      alicloud_vpc_name: "vpc-#{add_random_string}",
-      alicloud_vpc_description: "Test VPC for inspec",
-      alicloud_vpc_cidr: "10.0.0.0/16",
-      alicloud_vpc_vswitch_name: "vswitch-#{add_random_string}",
-      alicloud_vpc_vswitch_cidr: "10.0.1.0/24",
-      alicloud_security_group_name: "sg-#{add_random_string}",
-      alicloud_security_group_description: "Test security group for inspec",
-      alicloud_security_group_rule_port_range: "1000/9999",
-      alicloud_security_group_rule_port_in_range: 2020,
-      alicloud_security_group_rule_port_not_in_range: 10000,
-      alicloud_security_group_rule_cidr: "10.10.0.0/16",
-      alicloud_security_group_rule_cidr_not_in: "10.0.0.0/8",
-      alicloud_rds_db_name: "test-rds-#{add_random_string}",
-      alicloud_rds_db_engine: "MySQL",
-      alicloud_rds_db_engine_version: "8.0",
-      alicloud_rds_storage: "20",
-      alicloud_rds_instance_type: "mysql.n1.micro.1",
-      alicloud_bucket_acl_name: "ossbkt-#{add_random_string}",
-      alicloud_bucket_website_name: "ossbkt-#{add_random_string}",
-      alicloud_bucket_logging_target_name: "ossbkt-#{add_random_string}",
-      alicloud_bucket_logging_name: "ossbkt-#{add_random_string}",
-      alicloud_bucket_lifecycle_name: "ossbkt-#{add_random_string}",
-      alicloud_bucket_encrypted_name: "ossbkt-#{add_random_string}",
-      alicloud_bucket_tags_name: "ossbkt-#{add_random_string}",
-      alicloud_bucket_versioning_name: "ossbkt-#{add_random_string}",
-      alicloud_action_trail_ram_role_name: "atrr-#{add_random_string}",
-      alicloud_action_trail_ram_role_description: "ActionTrail ram role",
-      alicloud_action_trail_ram_policy_name: "atrp-#{add_random_string}",
-      alicloud_action_trail_ram_policy_description: "ActionTrail ram policy",
-      alicloud_action_trail_name: "at-#{add_random_string}",
-      alicloud_action_trail_bucket_name: "atb-#{add_random_string}",
-      alicloud_disk_name: "d-#{add_random_string}",
-      alicloud_disk_size: "20",
-      alicloud_disk_desc: "Test disk for inspec",
-      alicloud_disk_encrypted: false, # need to set up kms before setting to true
-      alicloud_disk_category: "cloud_efficiency",
-      alicloud_disk_delete_with_instance: true,
-      alicloud_disk_enable_auto_snapshot: true,
-      alicloud_disk_delete_auto_snapshot: true,
-      alicloud_slb_http_name: "slb-http-#{add_random_string}",
-      alicloud_slb_http_address_type: "internet",
-      alicloud_slb_http_specification: "slb.s1.small",
-      alicloud_slb_https_name: "slb-https-#{add_random_string}",
-      alicloud_slb_https_address_type: "internet",
-      alicloud_slb_https_specification: "slb.s1.small",
-      alicloud_slb_server_certificate_name: "slb-cert-#{add_random_string}",
-      alicloud_http_listener_fe_port: 80,
-      alicloud_http_listener_be_port: 80,
-      alicloud_http_listener_protocol: "http",
-      alicloud_http_listener_bandwidth: 1,
-      alicloud_https_listener_fe_port: 443,
-      alicloud_https_listener_be_port: 443,
-      alicloud_https_listener_protocol: "https",
-      alicloud_https_listener_bandwidth: 1,
-      alicloud_https_listener_tls_cipher_policy: "tls_cipher_policy_1_2",
-      alicloud_tags: { "test" => "tag" },
-      alicloud_ram_account_password_policy_password_reuse_prevention: 5,
-      alicloud_ram_account_password_policy_max_password_age: 180,
-      alicloud_ecs_instance_type: "ecs.g6.large",
-      alicloud_ecs_instance_system_disk_category: "cloud_efficiency",
-      alicloud_ecs_instance_image_id: "ubuntu_18_04_64_20G_alibase_20190624.vhd",
-      alicloud_ecs_instance_name: "instance-#{add_random_string}",
-      alicloud_ecs_instance_internet_max_bandwidth_out: 10,
-      alicloud_ecs_instance_disk_name: "disk-#{add_random_string}",
-      alicloud_ecs_instance_disk_size: 20,
-      alicloud_ecs_instance_disk_category: "cloud_efficiency",
-      alicloud_ecs_instance_disk_encrypted: "true",
-      alicloud_ram_user_name: "inspec-integration-test-#{add_random_string}",
-      alicloud_ram_user_display_name: "inspec-user",
-      alicloud_ram_user_mobile: "86-18688888888",
-      alicloud_ram_user_email: "user@inspec.com",
-      alicloud_ram_user_password: SecureRandom.urlsafe_base64(nil, true),
-      alicloud_ram_user_name_2: "inspec-integration-test-#{add_random_string}",
-      alicloud_ram_group_name: "test-group-#{add_random_string}",
-      alicloud_ram_role_name: "test-role-#{add_random_string}",
-      alicloud_ram_policy_name: "test-policy-#{add_random_string}",
-      alicloud_ram_attached_policy_name_1: "test-attached-policy-#{add_random_string}",
-      alicloud_ram_attached_policy_name_2: "test-attached-policy-#{add_random_string}",
+    # Simple flag to disable creation of resources (useful when prototyping new ones in isolation)
+    alicloud_enable_create: 1,
+    # Generic AliCloud resource parameters
+    alicloud_region: @alicloud_region,
+    alicloud_vpc_name: "vpc-#{add_random_string}",
+    alicloud_vpc_description: 'Test VPC for inspec',
+    alicloud_vpc_cidr: '10.0.0.0/16',
+    alicloud_vpc_vswitch_name: "vswitch-#{add_random_string}",
+    alicloud_vpc_vswitch_cidr: '10.0.1.0/24',
+    alicloud_security_group_name: "sg-#{add_random_string}",
+    alicloud_security_group_description: 'Test security group for inspec',
+    alicloud_security_group_rule_port_range: '1000/9999',
+    alicloud_security_group_rule_port_in_range: 2020,
+    alicloud_security_group_rule_port_not_in_range: 10_000,
+    alicloud_security_group_rule_cidr: '10.10.0.0/16',
+    alicloud_security_group_rule_cidr_not_in: '10.0.0.0/8',
+    alicloud_rds_db_name: "test-rds-#{add_random_string}",
+    alicloud_rds_db_engine: 'MySQL',
+    alicloud_rds_db_engine_version: '8.0',
+    alicloud_rds_storage: '20',
+    alicloud_rds_instance_type: 'mysql.n1.micro.1',
+    alicloud_bucket_acl_name: "ossbkt-#{add_random_string}",
+    alicloud_bucket_website_name: "ossbkt-#{add_random_string}",
+    alicloud_bucket_logging_target_name: "ossbkt-#{add_random_string}",
+    alicloud_bucket_logging_name: "ossbkt-#{add_random_string}",
+    alicloud_bucket_lifecycle_name: "ossbkt-#{add_random_string}",
+    alicloud_bucket_encrypted_name: "ossbkt-#{add_random_string}",
+    alicloud_bucket_tags_name: "ossbkt-#{add_random_string}",
+    alicloud_bucket_versioning_name: "ossbkt-#{add_random_string}",
+    alicloud_action_trail_ram_role_name: "atrr-#{add_random_string}",
+    alicloud_action_trail_ram_role_description: 'ActionTrail ram role',
+    alicloud_action_trail_ram_policy_name: "atrp-#{add_random_string}",
+    alicloud_action_trail_ram_policy_description: 'ActionTrail ram policy',
+    alicloud_action_trail_name: "at-#{add_random_string}",
+    alicloud_action_trail_bucket_name: "atb-#{add_random_string}",
+    alicloud_disk_name: "d-#{add_random_string}",
+    alicloud_disk_size: '20',
+    alicloud_disk_desc: 'Test disk for inspec',
+    alicloud_disk_encrypted: false, # need to set up kms before setting to true
+    alicloud_disk_category: 'cloud_efficiency',
+    alicloud_disk_delete_with_instance: true,
+    alicloud_disk_enable_auto_snapshot: true,
+    alicloud_disk_delete_auto_snapshot: true,
+    alicloud_slb_http_name: "slb-http-#{add_random_string}",
+    alicloud_slb_http_address_type: 'internet',
+    alicloud_slb_http_specification: 'slb.s1.small',
+    alicloud_slb_https_name: "slb-https-#{add_random_string}",
+    alicloud_slb_https_address_type: 'internet',
+    alicloud_slb_https_specification: 'slb.s1.small',
+    alicloud_slb_server_certificate_name: "slb-cert-#{add_random_string}",
+    alicloud_http_listener_fe_port: 80,
+    alicloud_http_listener_be_port: 80,
+    alicloud_http_listener_protocol: 'http',
+    alicloud_http_listener_bandwidth: 1,
+    alicloud_https_listener_fe_port: 443,
+    alicloud_https_listener_be_port: 443,
+    alicloud_https_listener_protocol: 'https',
+    alicloud_https_listener_bandwidth: 1,
+    alicloud_https_listener_tls_cipher_policy: 'tls_cipher_policy_1_2',
+    alicloud_tags: { 'test' => 'tag' },
+    alicloud_ram_account_password_policy_password_reuse_prevention: 5,
+    alicloud_ram_account_password_policy_max_password_age: 180,
+    alicloud_ecs_instance_type: 'ecs.g6.large',
+    alicloud_ecs_instance_system_disk_category: 'cloud_efficiency',
+    alicloud_ecs_instance_image_id: 'ubuntu_18_04_64_20G_alibase_20190624.vhd',
+    alicloud_ecs_instance_name: "instance-#{add_random_string}",
+    alicloud_ecs_instance_internet_max_bandwidth_out: 10,
+    alicloud_ecs_instance_disk_name: "disk-#{add_random_string}",
+    alicloud_ecs_instance_disk_size: 20,
+    alicloud_ecs_instance_disk_category: 'cloud_efficiency',
+    alicloud_ecs_instance_disk_encrypted: 'true',
+    alicloud_ram_user_name: "inspec-integration-test-#{add_random_string}",
+    alicloud_ram_user_display_name: 'inspec-user',
+    alicloud_ram_user_mobile: '86-18688888888',
+    alicloud_ram_user_email: 'user@inspec.com',
+    alicloud_ram_user_password: SecureRandom.urlsafe_base64(nil, true),
+    alicloud_ram_user_name_2: "inspec-integration-test-#{add_random_string}",
+    alicloud_ram_group_name: "test-group-#{add_random_string}",
+    alicloud_ram_role_name: "test-role-#{add_random_string}",
+    alicloud_ram_policy_name: "test-policy-#{add_random_string}",
+    alicloud_ram_attached_policy_name_1: "test-attached-policy-#{add_random_string}",
+    alicloud_ram_attached_policy_name_2: "test-attached-policy-#{add_random_string}"
   }
 
   def self.config
@@ -114,44 +113,44 @@ module AliCloudInspecConfig
   end
 
   # Create JSON for terraform
-  def self.store_json(file_name = "alicloud-inspec.tfvars.json")
+  def self.store_json(file_name = 'alicloud-inspec.tfvars.json')
     update_from_environment
-    File.open(File.join(File.dirname(__FILE__), "..", "build", file_name), "w") do |f|
+    File.open(File.join(File.dirname(__FILE__), '..', 'build', file_name), 'w') do |f|
       f.write(@config.to_json)
     end
   end
 
   # Create YAML for inspec
-  def self.store_yaml(file_name = "alicloud-inspec-attributes.yaml")
+  def self.store_yaml(file_name = 'alicloud-inspec-attributes.yaml')
     update_from_environment
-    File.open(File.join(File.dirname(__FILE__), "..", "build", file_name), "w") do |f|
+    File.open(File.join(File.dirname(__FILE__), '..', 'build', file_name), 'w') do |f|
       f.write(@config.to_yaml)
     end
   end
 
-  def self.get_tf_output_vars(file_name = "outputs.tf")
+  def self.get_tf_output_vars(file_name = 'outputs.tf')
     # let's assume that all lines starting with 'output' contain the desired target name
     # (brittle but this way we don't need to preserve a list)
     outputs = []
-    outputs_file = File.join(File.dirname(__FILE__), "..", "build", file_name)
+    outputs_file = File.join(File.dirname(__FILE__), '..', 'build', file_name)
     File.read(outputs_file).lines.each do |line|
-      next unless line.start_with?("output")
+      next unless line.start_with?('output')
 
-      outputs += [line.sub(/^output \"/, "").sub(/\" {\n/, "")]
+      outputs += [line.sub(/^output "/, '').sub(/" {\n/, '')]
     end
     outputs
   end
 
-  def self.update_yaml(file_name = "alicloud-inspec-attributes.yaml")
-    build_dir = File.join(File.dirname(__FILE__), "..", "build")
+  def self.update_yaml(file_name = 'alicloud-inspec-attributes.yaml')
+    build_dir = File.join(File.dirname(__FILE__), '..', 'build')
     contents = YAML.load_file(File.join(build_dir, file_name))
     outputs = get_tf_output_vars
     outputs.each do |tf|
       # also assuming single values here
-      value = `cd "#{build_dir}" && terraform output #{tf}`.chop.gsub(/"/, "")
+      value = `cd "#{build_dir}" && terraform output #{tf}`.chop.gsub(/"/, '')
       contents[tf.to_sym] = value
     end
-    File.open(File.join(File.dirname(__FILE__), "..", "build", file_name), "w") do |f|
+    File.open(File.join(File.dirname(__FILE__), '..', 'build', file_name), 'w') do |f|
       f.write(contents.to_yaml)
     end
   end

--- a/test/integration/verify/controls/alicloud_actiontrail_trail.rb
+++ b/test/integration/verify/controls/alicloud_actiontrail_trail.rb
@@ -1,25 +1,28 @@
-title "Test single AliCloud ActionTrail"
+# frozen_string_literal: true
 
-alicloud_action_trail_name = input(:alicloud_action_trail_name, value: "", description: "Action trail name")
-alicloud_action_trail_bucket_id = input(:alicloud_action_trail_bucket_id, value: "", description: "Action trail bucket name")
+title 'Test single AliCloud ActionTrail'
 
-control "alicloud-actiontrail-1.0" do
+alicloud_action_trail_name = input(:alicloud_action_trail_name, value: '', description: 'Action trail name')
+alicloud_action_trail_bucket_id = input(:alicloud_action_trail_bucket_id, value: '',
+                                                                          description: 'Action trail bucket name')
+
+control 'alicloud-actiontrail-1.0' do
   impact 1.0
-  title "Ensure AliCloud Action Trail has the correct properties."
+  title 'Ensure AliCloud Action Trail has the correct properties.'
 
   describe alicloud_actiontrail_trail(alicloud_action_trail_name) do
     it { should exist }
   end
 
-  describe alicloud_actiontrail_trail("not-there-trail") do
+  describe alicloud_actiontrail_trail('not-there-trail') do
     it { should_not exist }
   end
 
   describe alicloud_actiontrail_trail(trail_name: alicloud_action_trail_name) do
     it { should exist }
-    its("oss_bucket_name") { should eq alicloud_action_trail_bucket_id }
+    its('oss_bucket_name') { should eq alicloud_action_trail_bucket_id }
     # its("delivered_logs_days_ago") { should eq 0 }
-    its("status") { should cmp "Enable" }
-    its("trail_region") { should cmp "All" }
+    its('status') { should cmp 'Enable' }
+    its('trail_region') { should cmp 'All' }
   end
 end

--- a/test/integration/verify/controls/alicloud_actiontrail_trail.rb
+++ b/test/integration/verify/controls/alicloud_actiontrail_trail.rb
@@ -21,7 +21,6 @@ control 'alicloud-actiontrail-1.0' do
   describe alicloud_actiontrail_trail(trail_name: alicloud_action_trail_name) do
     it { should exist }
     its('oss_bucket_name') { should eq alicloud_action_trail_bucket_id }
-    # its("delivered_logs_days_ago") { should eq 0 }
     its('status') { should cmp 'Enable' }
     its('trail_region') { should cmp 'All' }
   end

--- a/test/integration/verify/controls/alicloud_actiontrail_trails.rb
+++ b/test/integration/verify/controls/alicloud_actiontrail_trails.rb
@@ -1,14 +1,16 @@
-title "Test AliCloud ActionTrails in bulk"
+# frozen_string_literal: true
 
-alicloud_action_trail_name = input(:alicloud_action_trail_name, value: "", description: "Action trail name")
+title 'Test AliCloud ActionTrails in bulk'
 
-control "alicloud-actiontrails-1.0" do
+alicloud_action_trail_name = input(:alicloud_action_trail_name, value: '', description: 'Action trail name')
+
+control 'alicloud-actiontrails-1.0' do
   impact 1.0
-  title "Ensure AlicCloud Action Trail plural resource has the correct properties."
+  title 'Ensure AlicCloud Action Trail plural resource has the correct properties.'
 
   describe alicloud_actiontrail_trails do
     it { should exist }
-    its("count") { should be >= 1 }
-    its("names") { should include alicloud_action_trail_name }
+    its('count') { should be >= 1 }
+    its('names') { should include alicloud_action_trail_name }
   end
 end

--- a/test/integration/verify/controls/alicloud_apsaradb_rds_instance.rb
+++ b/test/integration/verify/controls/alicloud_apsaradb_rds_instance.rb
@@ -1,48 +1,51 @@
-alicloud_rds_db_id = attribute(:alicloud_rds_db_id, value: "", description: "The Alicloud RDS DB identifier.")
-alicloud_rds_db_name = attribute(:alicloud_rds_db_name, value: "", description: "The Alicloud RDS DB name.")
-alicloud_rds_db_engine = attribute(:alicloud_rds_db_engine, value: "", description: "The Alicloud RDS DB engine.")
-alicloud_rds_db_engine_version = attribute(:alicloud_rds_db_engine_version, value: "", description: "The Alicloud RDS DB engine version.")
-alicloud_rds_storage = attribute(:alicloud_rds_storage, value: "", description: "The Alicloud RDS allocated storage.")
-alicloud_rds_instance_type = attribute(:alicloud_rds_instance_type, value: "", description: "The Alicloud RDS instance type.")
-alicloud_rds_vpc_id = attribute(:alicloud_vpc_id, value: "", description: "The Alicloud VPC ID for the DB.")
-alicloud_rds_security_ips = attribute(:alicloud_vpc_cidr, value: "", description: "The Alicloud RDS security IPs.")
+# frozen_string_literal: true
 
-title "Test single Alicloud ApsaraDB RDS Instance"
-control "alicloud-apsaradb-rds-instance-1.0" do
+alicloud_rds_db_id = attribute(:alicloud_rds_db_id, value: '', description: 'The Alicloud RDS DB identifier.')
+alicloud_rds_db_name = attribute(:alicloud_rds_db_name, value: '', description: 'The Alicloud RDS DB name.')
+alicloud_rds_db_engine = attribute(:alicloud_rds_db_engine, value: '', description: 'The Alicloud RDS DB engine.')
+alicloud_rds_db_engine_version = attribute(:alicloud_rds_db_engine_version, value: '',
+                                                                            description: 'The Alicloud RDS DB engine version.')
+alicloud_rds_storage = attribute(:alicloud_rds_storage, value: '', description: 'The Alicloud RDS allocated storage.')
+alicloud_rds_instance_type = attribute(:alicloud_rds_instance_type, value: '',
+                                                                    description: 'The Alicloud RDS instance type.')
+alicloud_rds_vpc_id = attribute(:alicloud_vpc_id, value: '', description: 'The Alicloud VPC ID for the DB.')
+alicloud_rds_security_ips = attribute(:alicloud_vpc_cidr, value: '', description: 'The Alicloud RDS security IPs.')
 
+title 'Test single Alicloud ApsaraDB RDS Instance'
+control 'alicloud-apsaradb-rds-instance-1.0' do
   impact 1.0
-  title "Ensure Alicloud ApsaraDB RDS Instance has the correct properties."
+  title 'Ensure Alicloud ApsaraDB RDS Instance has the correct properties.'
 
   describe alicloud_apsaradb_rds_instance(db_instance_id: alicloud_rds_db_id) do
     it { should exist }
-    its("instance_id") { should eq alicloud_rds_db_id }
-    its("description") { should eq alicloud_rds_db_name }
-    its("instance_type") { should eq "Primary" }
-    its("category") { should eq "Basic" }
-    its("engine") { should eq alicloud_rds_db_engine }
-    its("engine_version") { should eq alicloud_rds_db_engine_version }
-    its("allocated_storage") { should cmp alicloud_rds_storage }
-    its("storage_type") { should eq "cloud_ssd" }
-    its("memory") { should cmp "1024" }
-    its("cpus") { should cmp "1" }
-    its("instance_class") { should eq alicloud_rds_instance_type }
-    its("network_type") { should eq "VPC" }
-    its("net_type") { should eq "Intranet" }
-    its("vpc_id") { should eq alicloud_rds_vpc_id }
-    its("in_default_vpc") { should be false }
-    its("security_ips") { should_not cmp "" }
-    its("security_ips") { should_not include "0.0.0.0/0" }
-    its("security_ips") { should include alicloud_rds_security_ips }
-    its("security_ip_mode") { should eq "normal" }
-    its("status") { should eq "Running" }
-    its("pay_type") { should eq "Postpaid" }
+    its('instance_id') { should eq alicloud_rds_db_id }
+    its('description') { should eq alicloud_rds_db_name }
+    its('instance_type') { should eq 'Primary' }
+    its('category') { should eq 'Basic' }
+    its('engine') { should eq alicloud_rds_db_engine }
+    its('engine_version') { should eq alicloud_rds_db_engine_version }
+    its('allocated_storage') { should cmp alicloud_rds_storage }
+    its('storage_type') { should eq 'cloud_ssd' }
+    its('memory') { should cmp '1024' }
+    its('cpus') { should cmp '1' }
+    its('instance_class') { should eq alicloud_rds_instance_type }
+    its('network_type') { should eq 'VPC' }
+    its('net_type') { should eq 'Intranet' }
+    its('vpc_id') { should eq alicloud_rds_vpc_id }
+    its('in_default_vpc') { should be false }
+    its('security_ips') { should_not cmp '' }
+    its('security_ips') { should_not include '0.0.0.0/0' }
+    its('security_ips') { should include alicloud_rds_security_ips }
+    its('security_ip_mode') { should eq 'normal' }
+    its('status') { should eq 'Running' }
+    its('pay_type') { should eq 'Postpaid' }
   end
 
   describe alicloud_apsaradb_rds_instance(alicloud_rds_db_id) do
     it { should exist }
   end
 
-  describe alicloud_apsaradb_rds_instance("not-there") do
+  describe alicloud_apsaradb_rds_instance('not-there') do
     it { should_not exist }
   end
 end

--- a/test/integration/verify/controls/alicloud_apsaradb_rds_instances.rb
+++ b/test/integration/verify/controls/alicloud_apsaradb_rds_instances.rb
@@ -1,21 +1,22 @@
-alicloud_rds_db_id = attribute(:alicloud_rds_db_id, value: "", description: "The Alicloud RDS DB identifier.")
+# frozen_string_literal: true
 
-title "Test multiple Alicloud ApsaraDB RDS Instances"
-control "alicloud-apsaradb-rds-instances-1.0" do
+alicloud_rds_db_id = attribute(:alicloud_rds_db_id, value: '', description: 'The Alicloud RDS DB identifier.')
 
+title 'Test multiple Alicloud ApsaraDB RDS Instances'
+control 'alicloud-apsaradb-rds-instances-1.0' do
   impact 1.0
-  title "Ensure Alicloud ApsaraDB RDS Instances have the correct properties."
+  title 'Ensure Alicloud ApsaraDB RDS Instances have the correct properties.'
 
   describe alicloud_apsaradb_rds_instances do
     it { should exist }
-    its("db_instance_ids") { should include alicloud_rds_db_id }
+    its('db_instance_ids') { should include alicloud_rds_db_id }
   end
 
   alicloud_apsaradb_rds_instances.db_instance_ids.each do |db_instance_id|
     describe alicloud_apsaradb_rds_instance(db_instance_id) do
-      its("in_default_vpc") { should be false }
-      its("security_ips") { should_not cmp "" }
-      its("security_ips") { should_not include "0.0.0.0/0" }
+      its('in_default_vpc') { should be false }
+      its('security_ips') { should_not cmp '' }
+      its('security_ips') { should_not include '0.0.0.0/0' }
     end
   end
 end

--- a/test/integration/verify/controls/alicloud_disk.rb
+++ b/test/integration/verify/controls/alicloud_disk.rb
@@ -1,44 +1,49 @@
-alicloud_disk_id        = input(:alicloud_disk_id, value: "", description: "AliCloud Disk ID.")
-alicloud_disk_name      = input(:alicloud_disk_name, value: "", description: "AliCloud Disk Name.")
-alicloud_disk_desc      = input(:alicloud_disk_desc, value: "", description: "AliCloud Disk Desc.")
-alicloud_disk_size      = input(:alicloud_disk_size, value: "", description: "AliCloud Disk Size.")
-alicloud_disk_category  = input(:alicloud_disk_category, value: "", description: "AliCloud Disk Category.")
-alicloud_disk_encrypted = input(:alicloud_disk_encrypted, value: "", description: "AliCloud Disk Encrypted.")
-alicloud_disk_delete_with_instance = input(:alicloud_disk_delete_with_instance, value: "", description: "AliCloud Disk DeleteWithInstance.")
-alicloud_disk_enable_auto_snapshot = input(:alicloud_disk_enable_auto_snapshot, value: "", description: "AliCloud Disk EnableAutoSnapshot.")
-alicloud_disk_delete_auto_snapshot = input(:alicloud_disk_delete_auto_snapshot, value: "", description: "AliCloud Disk DeleteAutoSnapshot.")
+# frozen_string_literal: true
+
+alicloud_disk_id        = input(:alicloud_disk_id, value: '', description: 'AliCloud Disk ID.')
+alicloud_disk_name      = input(:alicloud_disk_name, value: '', description: 'AliCloud Disk Name.')
+alicloud_disk_desc      = input(:alicloud_disk_desc, value: '', description: 'AliCloud Disk Desc.')
+alicloud_disk_size      = input(:alicloud_disk_size, value: '', description: 'AliCloud Disk Size.')
+alicloud_disk_category  = input(:alicloud_disk_category, value: '', description: 'AliCloud Disk Category.')
+alicloud_disk_encrypted = input(:alicloud_disk_encrypted, value: '', description: 'AliCloud Disk Encrypted.')
+alicloud_disk_delete_with_instance = input(:alicloud_disk_delete_with_instance, value: '',
+                                                                                description: 'AliCloud Disk DeleteWithInstance.')
+alicloud_disk_enable_auto_snapshot = input(:alicloud_disk_enable_auto_snapshot, value: '',
+                                                                                description: 'AliCloud Disk EnableAutoSnapshot.')
+alicloud_disk_delete_auto_snapshot = input(:alicloud_disk_delete_auto_snapshot, value: '',
+                                                                                description: 'AliCloud Disk DeleteAutoSnapshot.')
 # alicloud_disk_tags      = input(:alicloud_disk_tags, value: "", description: "AliCloud Disk Tags.")
 
-title "Test single AliCloud Disk"
+title 'Test single AliCloud Disk'
 
-control "alicloud-disk-1.0" do
+control 'alicloud-disk-1.0' do
   impact 1.0
-  title "Ensure AliCloud Disk has the correct properties."
+  title 'Ensure AliCloud Disk has the correct properties.'
 
-  describe alicloud_disk(disk_id: "d-nosuchdisk") do
+  describe alicloud_disk(disk_id: 'd-nosuchdisk') do
     it { should_not exist }
   end
 
   describe alicloud_disk(disk_id: alicloud_disk_id) do
     it { should exist }
-    its("id") { should eq alicloud_disk_id }
-    its("name") { should eq alicloud_disk_name }
-    its("description") { should cmp alicloud_disk_desc }
-    its("size") { should cmp alicloud_disk_size }
-    its("category") { should cmp alicloud_disk_category }
-    its("encrypted") { should cmp alicloud_disk_encrypted }
-    its("delete_with_instance") { should cmp alicloud_disk_delete_with_instance }
-    its("enable_auto_snapshot") { should cmp alicloud_disk_enable_auto_snapshot }
-    its("delete_auto_snapshot") { should cmp alicloud_disk_delete_auto_snapshot }
+    its('id') { should eq alicloud_disk_id }
+    its('name') { should eq alicloud_disk_name }
+    its('description') { should cmp alicloud_disk_desc }
+    its('size') { should cmp alicloud_disk_size }
+    its('category') { should cmp alicloud_disk_category }
+    its('encrypted') { should cmp alicloud_disk_encrypted }
+    its('delete_with_instance') { should cmp alicloud_disk_delete_with_instance }
+    its('enable_auto_snapshot') { should cmp alicloud_disk_enable_auto_snapshot }
+    its('delete_auto_snapshot') { should cmp alicloud_disk_delete_auto_snapshot }
   end
 
   describe alicloud_disk(disk_name: alicloud_disk_name) do
     it { should exist }
-    its("id") { should eq alicloud_disk_id }
-    its("name") { should eq alicloud_disk_name }
+    its('id') { should eq alicloud_disk_id }
+    its('name') { should eq alicloud_disk_name }
   end
 
-  describe alicloud_disk(disk_id: alicloud_disk_id, region: "us-west-1") do
+  describe alicloud_disk(disk_id: alicloud_disk_id, region: 'us-west-1') do
     it { should_not exist }
   end
 end

--- a/test/integration/verify/controls/alicloud_disks.rb
+++ b/test/integration/verify/controls/alicloud_disks.rb
@@ -1,8 +1,10 @@
-title "Test AliCloud Disk in bulk"
+# frozen_string_literal: true
 
-control "alicloud-disks-1.0" do
+title 'Test AliCloud Disk in bulk'
+
+control 'alicloud-disks-1.0' do
   impact 1.0
-  title "Ensure AliCloud disk plural resource has the correct properties."
+  title 'Ensure AliCloud disk plural resource has the correct properties.'
 
   # Verify that you have disks defiend
   describe alicloud_disks do
@@ -11,6 +13,6 @@ control "alicloud-disks-1.0" do
 
   # Verify you have more than 1 disk
   describe alicloud_disks do
-    its("entries.count") { should be > 1 }
+    its('entries.count') { should be > 1 }
   end
 end

--- a/test/integration/verify/controls/alicloud_ecs_instance.rb
+++ b/test/integration/verify/controls/alicloud_ecs_instance.rb
@@ -1,47 +1,52 @@
-alicloud_instance_id = input(:alicloud_instance_id, value: "", description: "AliCloud test instance ID.")
-alicloud_ram_role_name = input(:alicloud_ram_role_name, value: "", description: "AliCloud RAM role name.")
+# frozen_string_literal: true
 
-title "Test single AliCloud ECS Instance"
+alicloud_instance_id = input(:alicloud_instance_id, value: '', description: 'AliCloud test instance ID.')
+alicloud_ram_role_name = input(:alicloud_ram_role_name, value: '', description: 'AliCloud RAM role name.')
 
-control "alicloud-instance-1.0" do
+title 'Test single AliCloud ECS Instance'
+
+control 'alicloud-instance-1.0' do
   impact 1.0
-  title "Ensure Alicloud ECS Instance Class has correct attributes"
+  title 'Ensure Alicloud ECS Instance Class has correct attributes'
 
-  describe alicloud_ecs_instance(instance_id: alicloud_instance_id) do  # gets region from env var
+  describe alicloud_ecs_instance(instance_id: alicloud_instance_id) do # gets region from env var
     it { should exist }
-    its("description") { should eq "" }
-    its("memory") { should eq 8192 }
-    its("instance_charge_type") { should eq "PostPaid" }
-    its("cpu") { should eq 2 }
-    its("instance_network_type") { should eq "vpc" }
-    its("public_ip_address") { should_not be_nil }
-    its("inner_ip_address") { should_not be_nil }
-    its("expired_time") { should_not be_nil }
-    its("image_id") { should_not be_nil }
-    its("eip_address") { should_not be_nil }
-    its("instance_type") { should eq "ecs.g6.large" }
-    its("host_name") { should_not be_nil }
-    its("vlan_id") { should_not be_nil }
-    its("status") { should eq "Running" }
-    its("io_optimized") { should eq "optimized" }
-    its("zone_id") { should_not be_nil }
-    its("cluster_id") { should_not be_nil }
-    its("stopped_mode") { should eq "Not-applicable" }
-    its("dedicated_host_attribute") { should_not be_nil }
-    its("security_group_ids") { should_not be_nil }
-    its("vpc_attributes") { should_not be_nil }
-    its("operation_locks") { should_not be_nil }
-    its("internet_charge_type") { should eq "PayByTraffic" }
-    its("instance_name") { should_not be_nil }
-    its("internet_max_bandwidth_out") { should_not be_nil }
-    its("internet_max_bandwidth_in") { should_not be_nil }
-    its("serial_number") { should_not be_nil }
-    its("creation_time") { should_not be_nil }
-    its("region_id") { should_not be_nil }
-    its("credit_specification") { should_not be_nil }
-    its("deletion_protection") { should be false }  # Can't test setting it to true in Terraform, if you do Terraform can't delete it
-    its("ram_roles") { should cmp [alicloud_ram_role_name] }
-    its("ram_roles") { should include alicloud_ram_role_name }
-    its("ram_roles.count") { should eq 1 }
+    its('description') { should eq '' }
+    its('memory') { should eq 8192 }
+    its('instance_charge_type') { should eq 'PostPaid' }
+    its('cpu') { should eq 2 }
+    its('instance_network_type') { should eq 'vpc' }
+    its('public_ip_address') { should_not be_nil }
+    its('inner_ip_address') { should_not be_nil }
+    its('expired_time') { should_not be_nil }
+    its('image_id') { should_not be_nil }
+    its('eip_address') { should_not be_nil }
+    its('instance_type') { should eq 'ecs.g6.large' }
+    its('host_name') { should_not be_nil }
+    its('vlan_id') { should_not be_nil }
+    its('status') { should eq 'Running' }
+    its('io_optimized') { should eq 'optimized' }
+    its('zone_id') { should_not be_nil }
+    its('cluster_id') { should_not be_nil }
+    its('stopped_mode') { should eq 'Not-applicable' }
+    its('dedicated_host_attribute') { should_not be_nil }
+    its('security_group_ids') { should_not be_nil }
+    its('vpc_attributes') { should_not be_nil }
+    its('operation_locks') { should_not be_nil }
+    its('internet_charge_type') { should eq 'PayByTraffic' }
+    its('instance_name') { should_not be_nil }
+    its('internet_max_bandwidth_out') { should_not be_nil }
+    its('internet_max_bandwidth_in') { should_not be_nil }
+    its('serial_number') { should_not be_nil }
+    its('creation_time') { should_not be_nil }
+    its('region_id') { should_not be_nil }
+    its('credit_specification') { should_not be_nil }
+    # Can't test setting it to true in Terraform, if you do Terraform can't delete it
+    its('deletion_protection') do
+      should be false
+    end
+    its('ram_roles') { should cmp [alicloud_ram_role_name] }
+    its('ram_roles') { should include alicloud_ram_role_name }
+    its('ram_roles.count') { should eq 1 }
   end
 end

--- a/test/integration/verify/controls/alicloud_ecs_instances.rb
+++ b/test/integration/verify/controls/alicloud_ecs_instances.rb
@@ -1,21 +1,23 @@
-alicloud_instance_id = input(:alicloud_instance_id, value: "", description: "AliCloud test instance ID.")
+# frozen_string_literal: true
 
-title "Test AliCloud ECS Group resource"
+alicloud_instance_id = input(:alicloud_instance_id, value: '', description: 'AliCloud test instance ID.')
 
-control "alicloud-instances-1.0" do
+title 'Test AliCloud ECS Group resource'
+
+control 'alicloud-instances-1.0' do
   impact 1.0
-  title "Ensure Alicloud ECS Instances Class has correct attributes"
+  title 'Ensure Alicloud ECS Instances Class has correct attributes'
 
   describe alicloud_ecs_instances do  # gets region from env var
     it { should exist }
-    its("entries.count") { should be >= 1 }
+    its('entries.count') { should be >= 1 }
   end
 
   describe alicloud_ecs_instances.where(deletion_protection: false) do
-    its("instance_ids") { should include alicloud_instance_id }
+    its('instance_ids') { should include alicloud_instance_id }
   end
 
   describe(alicloud_ecs_instances.where { ram_role.count == 1 }) do
-    its("instance_ids") { should include alicloud_instance_id }
+    its('instance_ids') { should include alicloud_instance_id }
   end
 end

--- a/test/integration/verify/controls/alicloud_oss_bucket.rb
+++ b/test/integration/verify/controls/alicloud_oss_bucket.rb
@@ -1,20 +1,24 @@
-title "Test single AliCloud OSS Bucket"
+# frozen_string_literal: true
 
-alicloud_action_trail_bucket_id = input(:alicloud_action_trail_bucket_id, value: "", description: "Action trail bucket name")
-alicloud_bucket_acl_name = input(:alicloud_bucket_acl_name, value: "", description: "OSS bucket name")
-alicloud_bucket_encrypted_name = input(:alicloud_bucket_encrypted_name, value: "", description: "OSS bucket name")
-alicloud_bucket_lifecycle_name = input(:alicloud_bucket_lifecycle_name, value: "", description: "OSS bucket name")
-alicloud_bucket_logging_name = input(:alicloud_bucket_logging_name, value: "", description: "OSS bucket name")
-alicloud_bucket_logging_target_name = input(:alicloud_bucket_logging_target_name, value: "", description: "OSS bucket name")
-alicloud_bucket_tags_name = input(:alicloud_bucket_tags_name, value: "", description: "OSS bucket name")
-alicloud_bucket_versioning_name = input(:alicloud_bucket_versioning_name, value: "", description: "OSS bucket name")
-alicloud_bucket_website_name = input(:alicloud_bucket_website_name, value: "", description: "OSS bucket name")
+title 'Test single AliCloud OSS Bucket'
 
-control "alicloud-ossbucket-1.0" do
+alicloud_action_trail_bucket_id = input(:alicloud_action_trail_bucket_id, value: '',
+                                                                          description: 'Action trail bucket name')
+alicloud_bucket_acl_name = input(:alicloud_bucket_acl_name, value: '', description: 'OSS bucket name')
+alicloud_bucket_encrypted_name = input(:alicloud_bucket_encrypted_name, value: '', description: 'OSS bucket name')
+alicloud_bucket_lifecycle_name = input(:alicloud_bucket_lifecycle_name, value: '', description: 'OSS bucket name')
+alicloud_bucket_logging_name = input(:alicloud_bucket_logging_name, value: '', description: 'OSS bucket name')
+alicloud_bucket_logging_target_name = input(:alicloud_bucket_logging_target_name, value: '',
+                                                                                  description: 'OSS bucket name')
+alicloud_bucket_tags_name = input(:alicloud_bucket_tags_name, value: '', description: 'OSS bucket name')
+alicloud_bucket_versioning_name = input(:alicloud_bucket_versioning_name, value: '', description: 'OSS bucket name')
+alicloud_bucket_website_name = input(:alicloud_bucket_website_name, value: '', description: 'OSS bucket name')
+
+control 'alicloud-ossbucket-1.0' do
   impact 1.0
-  title "Ensure AliCloud OSS Bucket has the correct properties."
+  title 'Ensure AliCloud OSS Bucket has the correct properties.'
 
-  describe alicloud_oss_bucket("not-there-bucket") do
+  describe alicloud_oss_bucket('not-there-bucket') do
     it { should_not exist }
   end
 
@@ -31,13 +35,13 @@ control "alicloud-ossbucket-1.0" do
   describe alicloud_oss_bucket(bucket_name: alicloud_bucket_encrypted_name) do
     it { should exist }
     it { should have_default_encryption_enabled }
-    its("bucket_lifecycle_rules") { should be_empty }
+    its('bucket_lifecycle_rules') { should be_empty }
   end
 
   describe alicloud_oss_bucket(bucket_name: alicloud_bucket_lifecycle_name) do
     it { should exist }
     it { should_not have_default_encryption_enabled }
-    its("bucket_lifecycle_rules") { should_not be_empty }
+    its('bucket_lifecycle_rules') { should_not be_empty }
   end
 
   describe alicloud_oss_bucket(bucket_name: alicloud_bucket_logging_name) do

--- a/test/integration/verify/controls/alicloud_oss_buckets.rb
+++ b/test/integration/verify/controls/alicloud_oss_buckets.rb
@@ -1,32 +1,35 @@
-title "Test AliCloud OSS Buckets in bulk"
+# frozen_string_literal: true
 
-alicloud_action_trail_bucket_id = input(:alicloud_action_trail_bucket_id, value: "", description: "Action trail bucket name")
-alicloud_bucket_acl_name = input(:alicloud_bucket_acl_name, value: "", description: "OSS bucket name")
-alicloud_bucket_encrypted_name = input(:alicloud_bucket_encrypted_name, value: "", description: "OSS bucket name")
-alicloud_bucket_lifecycle_name = input(:alicloud_bucket_lifecycle_name, value: "", description: "OSS bucket name")
-alicloud_bucket_logging_name = input(:alicloud_bucket_logging_name, value: "", description: "OSS bucket name")
-alicloud_bucket_logging_target_name = input(:alicloud_bucket_logging_target_name, value: "", description: "OSS bucket name")
-alicloud_bucket_tags_name = input(:alicloud_bucket_tags_name, value: "", description: "OSS bucket name")
-alicloud_bucket_versioning_name = input(:alicloud_bucket_versioning_name, value: "", description: "OSS bucket name")
-alicloud_bucket_website_name = input(:alicloud_bucket_website_name, value: "", description: "OSS bucket name")
+title 'Test AliCloud OSS Buckets in bulk'
 
-control "alicloud-oss-buckets-1.0" do
+alicloud_action_trail_bucket_id = input(:alicloud_action_trail_bucket_id, value: '',
+                                                                          description: 'Action trail bucket name')
+alicloud_bucket_acl_name = input(:alicloud_bucket_acl_name, value: '', description: 'OSS bucket name')
+alicloud_bucket_encrypted_name = input(:alicloud_bucket_encrypted_name, value: '', description: 'OSS bucket name')
+alicloud_bucket_lifecycle_name = input(:alicloud_bucket_lifecycle_name, value: '', description: 'OSS bucket name')
+alicloud_bucket_logging_name = input(:alicloud_bucket_logging_name, value: '', description: 'OSS bucket name')
+alicloud_bucket_logging_target_name = input(:alicloud_bucket_logging_target_name, value: '',
+                                                                                  description: 'OSS bucket name')
+alicloud_bucket_tags_name = input(:alicloud_bucket_tags_name, value: '', description: 'OSS bucket name')
+alicloud_bucket_versioning_name = input(:alicloud_bucket_versioning_name, value: '', description: 'OSS bucket name')
+alicloud_bucket_website_name = input(:alicloud_bucket_website_name, value: '', description: 'OSS bucket name')
 
+control 'alicloud-oss-buckets-1.0' do
   impact 1.0
-  title "Ensure AliCloud OSS Buckets plural resource has the correct properties."
+  title 'Ensure AliCloud OSS Buckets plural resource has the correct properties.'
 
   describe alicloud_oss_buckets do
     it { should exist }
-    its("count") { should be >= 9 }
-    its("bucket_names") { should include alicloud_action_trail_bucket_id }
-    its("bucket_names") { should include alicloud_bucket_acl_name }
-    its("bucket_names") { should include alicloud_bucket_encrypted_name }
-    its("bucket_names") { should include alicloud_bucket_lifecycle_name }
-    its("bucket_names") { should include alicloud_bucket_logging_name }
-    its("bucket_names") { should include alicloud_bucket_logging_target_name }
-    its("bucket_names") { should include alicloud_bucket_tags_name }
-    its("bucket_names") { should include alicloud_bucket_versioning_name }
-    its("bucket_names") { should include alicloud_bucket_website_name }
-    its("bucket_names") { should_not include "not-there-hopefully" }
+    its('count') { should be >= 9 }
+    its('bucket_names') { should include alicloud_action_trail_bucket_id }
+    its('bucket_names') { should include alicloud_bucket_acl_name }
+    its('bucket_names') { should include alicloud_bucket_encrypted_name }
+    its('bucket_names') { should include alicloud_bucket_lifecycle_name }
+    its('bucket_names') { should include alicloud_bucket_logging_name }
+    its('bucket_names') { should include alicloud_bucket_logging_target_name }
+    its('bucket_names') { should include alicloud_bucket_tags_name }
+    its('bucket_names') { should include alicloud_bucket_versioning_name }
+    its('bucket_names') { should include alicloud_bucket_website_name }
+    its('bucket_names') { should_not include 'not-there-hopefully' }
   end
 end

--- a/test/integration/verify/controls/alicloud_ram_access_key.rb
+++ b/test/integration/verify/controls/alicloud_ram_access_key.rb
@@ -1,19 +1,21 @@
-alicloud_ram_user_name = input(:alicloud_ram_user_name, value: "", description: "AliCloud RAM User's name.")
-alicloud_ram_access_key_id = input(:alicloud_ram_access_key_id, value: "", description: "AliCloud Access Key ID")
+# frozen_string_literal: true
 
-title "Test AliCloud access key"
+alicloud_ram_user_name = input(:alicloud_ram_user_name, value: '', description: "AliCloud RAM User's name.")
+alicloud_ram_access_key_id = input(:alicloud_ram_access_key_id, value: '', description: 'AliCloud Access Key ID')
 
-control "alicloud-access-key-1.0" do
+title 'Test AliCloud access key'
+
+control 'alicloud-access-key-1.0' do
   impact 1.0
-  title "Ensure Alicloud access key library has correct properties"
+  title 'Ensure Alicloud access key library has correct properties'
 
-  describe alicloud_access_key(ENV["ALICLOUD_ACCESS_KEY"]) do
-    its("access_key_id") { should eq ENV["ALICLOUD_ACCESS_KEY"] }
-    its("status") { should eq "Active" }
-    its("create_date") { should_not be_nil }
+  describe alicloud_access_key(ENV['ALICLOUD_ACCESS_KEY']) do
+    its('access_key_id') { should eq ENV['ALICLOUD_ACCESS_KEY'] }
+    its('status') { should eq 'Active' }
+    its('create_date') { should_not be_nil }
   end
 
-  describe alicloud_access_key("not-exists") do
+  describe alicloud_access_key('not-exists') do
     it { should_not exist }
   end
 

--- a/test/integration/verify/controls/alicloud_ram_access_keys.rb
+++ b/test/integration/verify/controls/alicloud_ram_access_keys.rb
@@ -1,19 +1,21 @@
-alicloud_ram_user_name = input(:alicloud_ram_user_name, value: "", description: "AliCloud RAM User's name.")
-alicloud_ram_access_key_id = input(:alicloud_ram_access_key_id, value: "", description: "AliCloud Access Key ID")
+# frozen_string_literal: true
 
-title "Test AliCloud access keys group"
+alicloud_ram_user_name = input(:alicloud_ram_user_name, value: '', description: "AliCloud RAM User's name.")
+alicloud_ram_access_key_id = input(:alicloud_ram_access_key_id, value: '', description: 'AliCloud Access Key ID')
 
-control "alicloud-access-keys-1.0" do
+title 'Test AliCloud access keys group'
+
+control 'alicloud-access-keys-1.0' do
   impact 1.0
-  title "Ensure Alicloud access key library has correct properties"
+  title 'Ensure Alicloud access key library has correct properties'
 
   describe alicloud_access_keys do
     it { should exist }
-    its("access_key_ids") { should include ENV["ALICLOUD_ACCESS_KEY"] }  # gets key of running user
+    its('access_key_ids') { should include ENV['ALICLOUD_ACCESS_KEY'] }  # gets key of running user
   end
 
   describe alicloud_access_keys(alicloud_ram_user_name) do
     it { should exist }
-    its("access_key_ids") { should include alicloud_ram_access_key_id }  # gets key of other user
+    its('access_key_ids') { should include alicloud_ram_access_key_id }  # gets key of other user
   end
 end

--- a/test/integration/verify/controls/alicloud_ram_password_policy.rb
+++ b/test/integration/verify/controls/alicloud_ram_password_policy.rb
@@ -1,17 +1,19 @@
-title "Test Alicloud RAM Password Policy"
+# frozen_string_literal: true
 
-control "alicloud-ram-1.0" do
+title 'Test Alicloud RAM Password Policy'
+
+control 'alicloud-ram-1.0' do
   impact 1.0
-  title "Ensure AliCloud RAM password policy has the correct properties"
+  title 'Ensure AliCloud RAM password policy has the correct properties'
 
   describe alicloud_ram_password_policy do
     it { should exist }
-    its("require_uppercase_characters") { should eq true }
-    its("require_lowercase_characters") { should eq true }
-    its("require_symbols") { should eq true }
-    its("require_numbers") { should eq true }
-    its("password_reuse_prevention") { should be >= 5 }
-    its("minimum_password_length") { should be >= 8 }
-    its("max_password_age") { should eq 180 }
+    its('require_uppercase_characters') { should eq true }
+    its('require_lowercase_characters') { should eq true }
+    its('require_symbols') { should eq true }
+    its('require_numbers') { should eq true }
+    its('password_reuse_prevention') { should be >= 5 }
+    its('minimum_password_length') { should be >= 8 }
+    its('max_password_age') { should eq 180 }
   end
 end

--- a/test/integration/verify/controls/alicloud_ram_policies.rb
+++ b/test/integration/verify/controls/alicloud_ram_policies.rb
@@ -1,36 +1,38 @@
-title "Test a collection of AliCloud RAM Policies"
+# frozen_string_literal: true
 
-alicloud_ram_policy_name = attribute(:alicloud_ram_policy_name, value: "", description: "The Alicloud RAM Policy name.")
-alicloud_ram_attached_policy_name_1 = attribute(:alicloud_ram_attached_policy_name_1, value: "", description: "The Alicloud RAM Attached Policy 1 name.")
+title 'Test a collection of AliCloud RAM Policies'
 
-control "alicloud-ram-policies-1.0" do
+alicloud_ram_policy_name = attribute(:alicloud_ram_policy_name, value: '', description: 'The Alicloud RAM Policy name.')
+alicloud_ram_attached_policy_name_1 = attribute(:alicloud_ram_attached_policy_name_1, value: '',
+                                                                                      description: 'The Alicloud RAM Attached Policy 1 name.')
 
+control 'alicloud-ram-policies-1.0' do
   impact 1.0
-  title "Ensure AliCLoud RAM Policies have the correct properties."
+  title 'Ensure AliCLoud RAM Policies have the correct properties.'
 
   describe alicloud_ram_policies do
     it { should exist }
-    its("policy_names") { should include "AdministratorAccess" }
+    its('policy_names') { should include 'AdministratorAccess' }
     # Ensure multiple truncated responses are returned
-    its("entries.count") { should be > 200 }
-    its("policy_names.count") { should be > 200 }
+    its('entries.count') { should be > 200 }
+    its('policy_names.count') { should be > 200 }
   end
 
-  describe alicloud_ram_policies(type: "System") do
+  describe alicloud_ram_policies(type: 'System') do
     it { should exist }
-    its("policy_names") { should include "AdministratorAccess" }
-    its("policy_names") { should_not include alicloud_ram_policy_name }
+    its('policy_names') { should include 'AdministratorAccess' }
+    its('policy_names') { should_not include alicloud_ram_policy_name }
   end
 
-  describe alicloud_ram_policies(type: "Custom") do
+  describe alicloud_ram_policies(type: 'Custom') do
     it { should exist }
-    its("policy_names") { should_not include "AdministratorAccess" }
-    its("policy_names") { should include alicloud_ram_policy_name }
-    its("policy_names") { should include alicloud_ram_attached_policy_name_1 }
+    its('policy_names') { should_not include 'AdministratorAccess' }
+    its('policy_names') { should include alicloud_ram_policy_name }
+    its('policy_names') { should include alicloud_ram_attached_policy_name_1 }
   end
 
-  describe alicloud_ram_policies(only_attached: true, type: "Custom") do
-    its("policy_names") { should_not include alicloud_ram_policy_name }
-    its("policy_names") { should include alicloud_ram_attached_policy_name_1 }
+  describe alicloud_ram_policies(only_attached: true, type: 'Custom') do
+    its('policy_names') { should_not include alicloud_ram_policy_name }
+    its('policy_names') { should include alicloud_ram_attached_policy_name_1 }
   end
 end

--- a/test/integration/verify/controls/alicloud_ram_policy.rb
+++ b/test/integration/verify/controls/alicloud_ram_policy.rb
@@ -1,70 +1,73 @@
-title "Test single Alicloud RAM Policy"
+# frozen_string_literal: true
 
-alicloud_ram_policy_name = attribute(:alicloud_ram_policy_name, value: "", description: "The Alicloud RAM Policy name.")
-alicloud_ram_attached_policy_name_1 = attribute(:alicloud_ram_attached_policy_name_1, value: "", description: "The Attached Alicloud RAM Policy 1 name.")
-alicloud_ram_attached_policy_name_2 = attribute(:alicloud_ram_attached_policy_name_2, value: "", description: "The Attached Alicloud RAM Policy 2 name.")
-alicloud_ram_user_name = attribute(:alicloud_ram_user_name, value: "", description: "The Alicloud RAM User name.")
-alicloud_ram_group_name = attribute(:alicloud_ram_group_name, value: "", description: "The Alicloud RAM Group name.")
-alicloud_ram_role_arn = attribute(:alicloud_ram_role_arn, value: "", description: "The Alicloud RAM Role ARN.")
+title 'Test single Alicloud RAM Policy'
 
-control "alicloud-ram-policy-1.0" do
+alicloud_ram_policy_name = attribute(:alicloud_ram_policy_name, value: '', description: 'The Alicloud RAM Policy name.')
+alicloud_ram_attached_policy_name_1 = attribute(:alicloud_ram_attached_policy_name_1, value: '',
+                                                                                      description: 'The Attached Alicloud RAM Policy 1 name.')
+alicloud_ram_attached_policy_name_2 = attribute(:alicloud_ram_attached_policy_name_2, value: '',
+                                                                                      description: 'The Attached Alicloud RAM Policy 2 name.')
+alicloud_ram_user_name = attribute(:alicloud_ram_user_name, value: '', description: 'The Alicloud RAM User name.')
+alicloud_ram_group_name = attribute(:alicloud_ram_group_name, value: '', description: 'The Alicloud RAM Group name.')
+alicloud_ram_role_arn = attribute(:alicloud_ram_role_arn, value: '', description: 'The Alicloud RAM Role ARN.')
 
+control 'alicloud-ram-policy-1.0' do
   impact 1.0
-  title "Ensure Alicloud RAM Policy has the correct properties."
+  title 'Ensure Alicloud RAM Policy has the correct properties.'
 
-  describe alicloud_ram_policy(policy_name: "DoesNotExist") do
+  describe alicloud_ram_policy(policy_name: 'DoesNotExist') do
     it { should_not exist }
   end
 
-  describe alicloud_ram_policy("AliyunSupportFullAccess") do
+  describe alicloud_ram_policy('AliyunSupportFullAccess') do
     it { should exist }
   end
 
-  describe alicloud_ram_policy(policy_name: "AliyunSupportFullAccess", type: "Custom") do
+  describe alicloud_ram_policy(policy_name: 'AliyunSupportFullAccess', type: 'Custom') do
     it { should_not exist }
   end
 
-  describe alicloud_ram_policy(policy_name: alicloud_ram_policy_name, type: "Custom") do
+  describe alicloud_ram_policy(policy_name: alicloud_ram_policy_name, type: 'Custom') do
     it { should exist }
-    it { should_not have_statement("Effect" => "Allow", "Resource" => "*", "Action" => "*") }
-    it { should have_statement("Effect" => "Allow", "Resource" => "*", "Action" => "ecs:Describe*") }
-    it { should have_statement("Effect" => "Allow", "Resource" => "acs:oss:::*", "NotAction" => "oss:DeleteBucket") }
-    its("statement_count") { should be 2 }
-    its("default_version") { should cmp "v1" }
+    it { should_not have_statement('Effect' => 'Allow', 'Resource' => '*', 'Action' => '*') }
+    it { should have_statement('Effect' => 'Allow', 'Resource' => '*', 'Action' => 'ecs:Describe*') }
+    it { should have_statement('Effect' => 'Allow', 'Resource' => 'acs:oss:::*', 'NotAction' => 'oss:DeleteBucket') }
+    its('statement_count') { should be 2 }
+    its('default_version') { should cmp 'v1' }
     it { should_not be_attached }
-    its("attached_user_count") { should eq 0 }
-    its("attached_group_count") { should eq 0 }
-    its("attached_role_count") { should eq 0 }
-    its("attachment_count") { should eq 0 }
+    its('attached_user_count') { should eq 0 }
+    its('attached_group_count') { should eq 0 }
+    its('attached_role_count') { should eq 0 }
+    its('attachment_count') { should eq 0 }
   end
 
-  describe alicloud_ram_policy(policy_name: alicloud_ram_policy_name, type: "System") do
+  describe alicloud_ram_policy(policy_name: alicloud_ram_policy_name, type: 'System') do
     it { should_not exist }
   end
 
   describe alicloud_ram_policy(policy_name: alicloud_ram_attached_policy_name_1) do
-    it { should_not be_attached_to_user("fake-user") }
-    it { should_not be_attached_to_role("fake-role") }
+    it { should_not be_attached_to_user('fake-user') }
+    it { should_not be_attached_to_role('fake-role') }
     it { should be_attached_to_role(alicloud_ram_role_arn) }
     it { should be_attached }
-    its("attached_roles") { should include alicloud_ram_role_arn }
-    its("attached_user_count") { should eq 0 }
-    its("attached_group_count") { should eq 0 }
-    its("attached_role_count") { should eq 1 }
-    its("attachment_count") { should eq 1 }
+    its('attached_roles') { should include alicloud_ram_role_arn }
+    its('attached_user_count') { should eq 0 }
+    its('attached_group_count') { should eq 0 }
+    its('attached_role_count') { should eq 1 }
+    its('attachment_count') { should eq 1 }
     # Test Action in an array
-    it { should have_statement(Action: ["ecs:Describe*"]) }
+    it { should have_statement(Action: ['ecs:Describe*']) }
   end
 
-  describe alicloud_ram_policy(policy_name: alicloud_ram_attached_policy_name_2, type: "Custom") do
+  describe alicloud_ram_policy(policy_name: alicloud_ram_attached_policy_name_2, type: 'Custom') do
     it { should be_attached_to_user(alicloud_ram_user_name) }
     it { should be_attached_to_group(alicloud_ram_group_name) }
     it { should be_attached }
-    its("attached_users") { should include alicloud_ram_user_name }
-    its("attached_user_count") { should eq 1 }
-    its("attached_groups") { should include alicloud_ram_group_name }
-    its("attached_group_count") { should eq 1 }
-    its("attached_role_count") { should eq 0 }
-    its("attachment_count") { should eq 2 }
+    its('attached_users') { should include alicloud_ram_user_name }
+    its('attached_user_count') { should eq 1 }
+    its('attached_groups') { should include alicloud_ram_group_name }
+    its('attached_group_count') { should eq 1 }
+    its('attached_role_count') { should eq 0 }
+    its('attachment_count') { should eq 2 }
   end
 end

--- a/test/integration/verify/controls/alicloud_ram_user.rb
+++ b/test/integration/verify/controls/alicloud_ram_user.rb
@@ -1,48 +1,55 @@
-alicloud_ram_user_name              = input(:alicloud_ram_user_name, value: "", description: "AliCloud RAM User's name.")
-alicloud_ram_user_display_name      = input(:alicloud_ram_user_display_name, value: "", description: "AliCloud RAM User's display name.")
-alicloud_ram_user_mobile            = input(:alicloud_ram_user_mobile, value: "", description: "AliCloud RAM User's mobile.")
-alicloud_ram_user_email             = input(:alicloud_ram_user_email, value: "", description: "AliCloud RAM User's Email.")
-alicloud_ram_user_name_2            = input(:alicloud_ram_user_name_2, value: "", description: "AliCloud RAM Second User's name.")
+# frozen_string_literal: true
 
-title "Test single Alicloud RAM user"
+alicloud_ram_user_name = input(:alicloud_ram_user_name, value: '',
+                                                        description: "AliCloud RAM User's name.")
+alicloud_ram_user_display_name = input(:alicloud_ram_user_display_name, value: '',
+                                                                        description: "AliCloud RAM User's display name.")
+alicloud_ram_user_mobile = input(:alicloud_ram_user_mobile, value: '',
+                                                            description: "AliCloud RAM User's mobile.")
+alicloud_ram_user_email = input(:alicloud_ram_user_email, value: '',
+                                                          description: "AliCloud RAM User's Email.")
+alicloud_ram_user_name_2 = input(:alicloud_ram_user_name_2, value: '',
+                                                            description: "AliCloud RAM Second User's name.")
 
-control "alicloud-ram-user-1.0" do
+title 'Test single Alicloud RAM user'
+
+control 'alicloud-ram-user-1.0' do
   impact 1.0
-  title "Ensure RAM user library has correct properties"
+  title 'Ensure RAM user library has correct properties'
 
   describe alicloud_ram_user(alicloud_ram_user_name) do
     it { should exist }
     it { should have_console_access }
     it { should have_active_access_key }
     it { should have_console_and_key_access }
-    its("update_date") { should_not be_nil }
-    its("user_name") { should eq alicloud_ram_user_name }
-    its("email") { should eq alicloud_ram_user_email }
-    its("user_id") { should_not be_nil }
-    its("comments") { should_not be_nil }
-    its("display_name") { should eq alicloud_ram_user_display_name }
-    its("last_login_date") { should_not be_nil }
-    its("create_date") { should_not be_nil }
-    its("mobile_phone") { should eq alicloud_ram_user_mobile }
-    its("access_keys.count") { should eq 2 }
-    its("active_access_keys.count") { should be <= 1 }
-    its("has_console_access?") { should be true }
-    its("has_active_access_key?") { should eq true }
-    its("has_console_and_key_access?") { should be true }
+    its('update_date') { should_not be_nil }
+    its('user_name') { should eq alicloud_ram_user_name }
+    its('email') { should eq alicloud_ram_user_email }
+    its('user_id') { should_not be_nil }
+    its('comments') { should_not be_nil }
+    its('display_name') { should eq alicloud_ram_user_display_name }
+    its('last_login_date') { should_not be_nil }
+    its('create_date') { should_not be_nil }
+    its('mobile_phone') { should eq alicloud_ram_user_mobile }
+    its('access_keys.count') { should eq 2 }
+    its('active_access_keys.count') { should be <= 1 }
+    its('has_console_access?') { should be true }
+    its('has_active_access_key?') { should eq true }
+    its('has_console_and_key_access?') { should be true }
   end
 
   describe alicloud_ram_user(user_name: alicloud_ram_user_name_2) do
     it { should_not have_console_access }
     it { should_not have_active_access_key }
     it { should_not have_console_and_key_access }
-    its("access_keys.count") { should eq 0 }
-    its("active_access_keys.count") { should eq 0 }
-    its("has_console_access?") { should be false }
-    its("has_active_access_key?") { should eq false }
-    its("has_console_and_key_access?") { should be false }
+    its('access_keys.count') { should eq 0 }
+    its('active_access_keys.count') { should eq 0 }
+    its('has_console_access?') { should be false }
+    its('has_active_access_key?') { should eq false }
+    its('has_console_and_key_access?') { should be false }
   end
 
-  describe alicloud_ram_user("no-such-user") do
+  describe alicloud_ram_user('no-such-user') do
     it { should_not exist }
   end
 end

--- a/test/integration/verify/controls/alicloud_ram_user_mfa.rb
+++ b/test/integration/verify/controls/alicloud_ram_user_mfa.rb
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
+
 # no terraform module for mfa yet https://www.terraform.io/docs/providers/alicloud/index.html
 # alicloud_ram_user_name = input(:alicloud_ram_user_name, value: "", description: "AliCloud RAM User's name.")
 # alicloud_ram_user_mfa_serial_number   = input(:alicloud_ram_user_mfa_serial_number, value: '', description: 'AliCloud RAM User\'s mfa serial number.')
 
-title "Test Alicloud RAM User MFA"
+title 'Test Alicloud RAM User MFA'
 
-control "alicloud-ram-user-mfa-1.0" do
+control 'alicloud-ram-user-mfa-1.0' do
   impact 1.0
-  title "Ensure RAM user MFA library has correct properties"
+  title 'Ensure RAM user MFA library has correct properties'
 
   # describe alicloud_ram_user_mfa(alicloud_ram_user_name) do
   #   it { should exist }

--- a/test/integration/verify/controls/alicloud_ram_users.rb
+++ b/test/integration/verify/controls/alicloud_ram_users.rb
@@ -1,25 +1,27 @@
-alicloud_ram_user_name = input(:alicloud_ram_user_name, value: "", description: "AliCloud RAM User's name.")
-alicloud_ram_user_name_2 = input(:alicloud_ram_user_name_2, value: "", description: "AliCloud second RAM User's name.")
+# frozen_string_literal: true
 
-title "Test Alicloud RAM plural users"
+alicloud_ram_user_name = input(:alicloud_ram_user_name, value: '', description: "AliCloud RAM User's name.")
+alicloud_ram_user_name_2 = input(:alicloud_ram_user_name_2, value: '', description: "AliCloud second RAM User's name.")
 
-control "alicloud-ram-users-1.0" do
+title 'Test Alicloud RAM plural users'
+
+control 'alicloud-ram-users-1.0' do
   impact 1.0
-  title "Ensure RAM user list library has correct properties"
+  title 'Ensure RAM user list library has correct properties'
 
   describe alicloud_ram_users do
-    its("entries.count") { should be > 1 }
+    its('entries.count') { should be > 1 }
   end
 
   describe alicloud_ram_users.where(has_console_access: true) do
-    its("user_names") { should include alicloud_ram_user_name }
+    its('user_names') { should include alicloud_ram_user_name }
   end
 
   describe alicloud_ram_users.where(has_console_and_key_access: true) do
-    its("user_names") { should include alicloud_ram_user_name }
+    its('user_names') { should include alicloud_ram_user_name }
   end
 
   describe alicloud_ram_users.where(has_console_access: false) do
-    its("user_names") { should include alicloud_ram_user_name_2 }
+    its('user_names') { should include alicloud_ram_user_name_2 }
   end
 end

--- a/test/integration/verify/controls/alicloud_region.rb
+++ b/test/integration/verify/controls/alicloud_region.rb
@@ -1,25 +1,28 @@
-title "Test single AliCloud region"
+# frozen_string_literal: true
 
-alicloud_region_exists = input(:alicloud_region_exists, value: "eu-west-1", description: "An AliCloud region.")
-alicloud_region_endpoint_exists = input(:alicloud_region_endpoint_exists, value: "ecs.eu-west-1.aliyuncs.com", description: "An AliCloud region.")
+title 'Test single AliCloud region'
 
-control "alicloud-region-1.0" do
+alicloud_region_exists = input(:alicloud_region_exists, value: 'eu-west-1', description: 'An AliCloud region.')
+alicloud_region_endpoint_exists = input(:alicloud_region_endpoint_exists, value: 'ecs.eu-west-1.aliyuncs.com',
+                                                                          description: 'An AliCloud region.')
+
+control 'alicloud-region-1.0' do
   impact 1.0
-  title "Ensure AliCloud region has the correct properties."
+  title 'Ensure AliCloud region has the correct properties.'
 
   describe alicloud_region(region_name: alicloud_region_exists) do
     it { should exist }
-    its("region_name") { should eq alicloud_region_exists }
-    its("endpoint") { should eq alicloud_region_endpoint_exists }
+    its('region_name') { should eq alicloud_region_exists }
+    its('endpoint') { should eq alicloud_region_endpoint_exists }
   end
 
   describe alicloud_region(alicloud_region_exists) do
     it { should exist }
-    its("region_name") { should eq alicloud_region_exists }
-    its("endpoint") { should eq alicloud_region_endpoint_exists }
+    its('region_name') { should eq alicloud_region_exists }
+    its('endpoint') { should eq alicloud_region_endpoint_exists }
   end
 
-  describe alicloud_region("not-a-real-region-1") do
+  describe alicloud_region('not-a-real-region-1') do
     it { should_not exist }
   end
 end

--- a/test/integration/verify/controls/alicloud_regions.rb
+++ b/test/integration/verify/controls/alicloud_regions.rb
@@ -1,13 +1,15 @@
-title "Test AliCloud Regions in bulk"
+# frozen_string_literal: true
 
-control "alicloud-regions-1.0" do
+title 'Test AliCloud Regions in bulk'
+
+control 'alicloud-regions-1.0' do
   impact 1.0
-  title "Ensure AliCloud regions plural resource has the correct properties."
+  title 'Ensure AliCloud regions plural resource has the correct properties.'
 
   describe alicloud_regions do
     it { should exist }
-    its("count") { should be >= 1 }
-    its("region_names") { should include "eu-west-1" }
-    its("endpoints") { should include "ecs.eu-west-1.aliyuncs.com" }
+    its('count') { should be >= 1 }
+    its('region_names') { should include 'eu-west-1' }
+    its('endpoints') { should include 'ecs.eu-west-1.aliyuncs.com' }
   end
 end

--- a/test/integration/verify/controls/alicloud_security_group.rb
+++ b/test/integration/verify/controls/alicloud_security_group.rb
@@ -1,37 +1,54 @@
-alicloud_vpc_id = input(:alicloud_vpc_id, value: "", description: "AliCloud VPC ID.")
-alicloud_security_group_alpha_id = input(:alicloud_security_group_alpha_id, value: "", description: "AliCloud Security Group ID.")
-alicloud_security_group_name = input(:alicloud_security_group_name, value: "", description: "AliCloud Security Group name.")
-alicloud_security_group_description = input(:alicloud_security_group_description, value: "", description: "AliCloud Security Group name.")
-alicloud_security_group_rule_port_in_range = input(:alicloud_security_group_rule_port_in_range, value: "", description: "a port in AliCloud Security Group ingress rule port range")
-alicloud_security_group_rule_port_not_in_range = input(:alicloud_security_group_rule_port_not_in_range, value: "", description: "a port not in AliCloud Security Group ingress rule port range")
-alicloud_security_group_rule_cidr = input(:alicloud_security_group_rule_cidr, value: "", description: "AliCloud Security Group ingress rule IPv4 range")
-alicloud_security_group_rule_cidr_not_in = input(:alicloud_security_group_rule_cidr_not_in, value: "", description: "a CIDR not in AliCloud Security Group ingress rule IPv4 range")
+# frozen_string_literal: true
 
-title "Test single AliCloud Security Groups"
+alicloud_vpc_id = input(:alicloud_vpc_id, value: '', description: 'AliCloud VPC ID.')
+alicloud_security_group_alpha_id = input(:alicloud_security_group_alpha_id, value: '',
+                                                                            description: 'AliCloud Security Group ID.')
+alicloud_security_group_name = input(:alicloud_security_group_name, value: '',
+                                                                    description: 'AliCloud Security Group name.')
+alicloud_security_group_description = input(:alicloud_security_group_description, value: '',
+                                                                                  description: 'AliCloud Security Group name.')
+alicloud_security_group_rule_port_in_range = input(:alicloud_security_group_rule_port_in_range, value: '',
+                                                                                                description: 'a port in AliCloud Security Group ingress rule port range')
+alicloud_security_group_rule_port_not_in_range = input(:alicloud_security_group_rule_port_not_in_range, value: '',
+                                                                                                        description: 'a port not in AliCloud Security Group ingress rule port range')
+alicloud_security_group_rule_cidr = input(:alicloud_security_group_rule_cidr, value: '',
+                                                                              description: 'AliCloud Security Group ingress rule IPv4 range')
+alicloud_security_group_rule_cidr_not_in = input(:alicloud_security_group_rule_cidr_not_in, value: '',
+                                                                                            description: 'a CIDR not in AliCloud Security Group ingress rule IPv4 range')
 
-control "alicloud-security-group-1.0" do
+title 'Test single AliCloud Security Groups'
+
+control 'alicloud-security-group-1.0' do
   impact 1.0
-  title "Ensure AliCloud security group has the correct properties."
+  title 'Ensure AliCloud security group has the correct properties.'
 
-  describe alicloud_security_group(group_id: "no-such-security-group") do
+  describe alicloud_security_group(group_id: 'no-such-security-group') do
     it { should_not exist }
   end
 
   describe alicloud_security_group(alicloud_security_group_alpha_id) do
     it { should exist }
-    its("vpc_id") { should eq alicloud_vpc_id }
-    its("group_name") { should eq alicloud_security_group_name }
-    its("description") { should cmp alicloud_security_group_description }
-    its("inbound_rules.count") { should be 1 }
-    its("outbound_rules.count") { should be_zero }
-    it { should allow_in(port: alicloud_security_group_rule_port_in_range, ipv4_range: alicloud_security_group_rule_cidr) }
-    it { should_not allow_in(port: alicloud_security_group_rule_port_not_in_range, ipv4_range: alicloud_security_group_rule_cidr) }
-    it { should_not allow_in(port: alicloud_security_group_rule_port_in_range, ipv4_range: alicloud_security_group_rule_cidr_not_in) }
+    its('vpc_id') { should eq alicloud_vpc_id }
+    its('group_name') { should eq alicloud_security_group_name }
+    its('description') { should cmp alicloud_security_group_description }
+    its('inbound_rules.count') { should be 1 }
+    its('outbound_rules.count') { should be_zero }
+    it {
+      should allow_in(port: alicloud_security_group_rule_port_in_range, ipv4_range: alicloud_security_group_rule_cidr)
+    }
+    it {
+      should_not allow_in(port: alicloud_security_group_rule_port_not_in_range,
+                          ipv4_range: alicloud_security_group_rule_cidr)
+    }
+    it {
+      should_not allow_in(port: alicloud_security_group_rule_port_in_range,
+                          ipv4_range: alicloud_security_group_rule_cidr_not_in)
+    }
     it { should allow_in(ipv4_range: alicloud_security_group_rule_cidr) }
     it { should_not allow_in(ipv4_range: alicloud_security_group_rule_cidr_not_in) }
   end
 
-  describe alicloud_security_group(group_id: alicloud_security_group_alpha_id, region: "us-west-1") do
+  describe alicloud_security_group(group_id: alicloud_security_group_alpha_id, region: 'us-west-1') do
     it { should_not exist }
   end
 end

--- a/test/integration/verify/controls/alicloud_security_groups.rb
+++ b/test/integration/verify/controls/alicloud_security_groups.rb
@@ -1,8 +1,10 @@
-title "Test AliCloud Security Groups in bulk"
+# frozen_string_literal: true
 
-control "alicloud-security-groups-1.0" do
+title 'Test AliCloud Security Groups in bulk'
+
+control 'alicloud-security-groups-1.0' do
   impact 1.0
-  title "Ensure AliCloud security group plural resource has the correct properties."
+  title 'Ensure AliCloud security group plural resource has the correct properties.'
 
   # Verify that you have security groups defined
   describe alicloud_security_groups do
@@ -12,6 +14,6 @@ control "alicloud-security-groups-1.0" do
   # Verify you have more than the default security group
   # We are creating 20 additional security groups to test the AliCloudCommonClient pagination code
   describe alicloud_security_groups do
-    its("entries.count") { should be > 20 }
+    its('entries.count') { should be > 20 }
   end
 end

--- a/test/integration/verify/controls/alicloud_slb.rb
+++ b/test/integration/verify/controls/alicloud_slb.rb
@@ -1,37 +1,38 @@
-alicloud_slb_http_id = input(:alicloud_slb_http_id, value: "", description: "AliCloud slb http ID.")
-alicloud_slb_https_id = input(:alicloud_slb_https_id, value: "", description: "AliCloud slb https ID.")
+# frozen_string_literal: true
 
-title "Test single AliCloud Server Load Balancer"
+alicloud_slb_http_id = input(:alicloud_slb_http_id, value: '', description: 'AliCloud slb http ID.')
+alicloud_slb_https_id = input(:alicloud_slb_https_id, value: '', description: 'AliCloud slb https ID.')
 
-control "alicloud-slb-1.0" do
+title 'Test single AliCloud Server Load Balancer'
+
+control 'alicloud-slb-1.0' do
   impact 1.0
-  title "Ensure AliCloud Server Load Balancer has the correct properties."
+  title 'Ensure AliCloud Server Load Balancer has the correct properties.'
 
-  describe alicloud_slb(slb_id: "no-such-slb") do
+  describe alicloud_slb(slb_id: 'no-such-slb') do
     it { should_not exist }
   end
 
   describe alicloud_slb(alicloud_slb_http_id) do
     it { should exist }
-    its("https_listeners?") { should eq false }
-    its("https_only?") { should eq false }
+    its('https_listeners?') { should eq false }
+    its('https_only?') { should eq false }
   end
 
   describe alicloud_slb(alicloud_slb_https_id) do
     it { should exist }
-    its("https_listeners?") { should eq true }
-    its("https_only?") { should eq true }
+    its('https_listeners?') { should eq true }
+    its('https_only?') { should eq true }
   end
 
-  describe alicloud_slb(slb_id: alicloud_slb_https_id, region: "us-west-1") do
+  describe alicloud_slb(slb_id: alicloud_slb_https_id, region: 'us-west-1') do
     it { should_not exist }
   end
 
   ### test slb_https_listener
   alicloud_slb(alicloud_slb_https_id).https_ports.each do |port|
     describe alicloud_slb_https_listener(slb_id: alicloud_slb_https_id, listener_port: port) do
-      its("tls_cipher_policy") { should eq "tls_cipher_policy_1_2" }
+      its('tls_cipher_policy') { should eq 'tls_cipher_policy_1_2' }
     end
   end
-
 end

--- a/test/integration/verify/controls/alicloud_slbs.rb
+++ b/test/integration/verify/controls/alicloud_slbs.rb
@@ -1,8 +1,10 @@
-title "Test AliCloud Server Load Balancers in bulk"
+# frozen_string_literal: true
 
-control "alicloud-slbs-1.0" do
+title 'Test AliCloud Server Load Balancers in bulk'
+
+control 'alicloud-slbs-1.0' do
   impact 1.0
-  title "Ensure AliCloud server load balancers plural resource has the correct properties."
+  title 'Ensure AliCloud server load balancers plural resource has the correct properties.'
 
   # Verify that you have server load balancers defined
   describe alicloud_slbs do
@@ -11,6 +13,6 @@ control "alicloud-slbs-1.0" do
 
   # Verify you have more than the default security group
   describe alicloud_slbs do
-    its("entries.count") { should be > 1 }
+    its('entries.count') { should be > 1 }
   end
 end

--- a/test/integration/verify/controls/alicloud_sts_caller_identity.rb
+++ b/test/integration/verify/controls/alicloud_sts_caller_identity.rb
@@ -1,11 +1,13 @@
-title "Ensure AliCloud credentials being used for the Inspec scan have the correct properties."
+# frozen_string_literal: true
 
-control "alicloud-sts-caller-identity-1.0" do
+title 'Ensure AliCloud credentials being used for the Inspec scan have the correct properties.'
+
+control 'alicloud-sts-caller-identity-1.0' do
   impact 1.0
-  title "Ensure AliCloud STS caller identity has the correct properties."
+  title 'Ensure AliCloud STS caller identity has the correct properties.'
 
   describe alicloud_sts_caller_identity do
     it { should exist }
-    its("arn") { should_not be_nil }
+    its('arn') { should_not be_nil }
   end
 end

--- a/test/integration/verify/controls/alicloud_vpc.rb
+++ b/test/integration/verify/controls/alicloud_vpc.rb
@@ -1,29 +1,31 @@
-title "Test single AliCloud VPC"
+# frozen_string_literal: true
 
-alicloud_vpc_id = input(:alicloud_vpc_id, value: "", description: "AliCloud VPC ID")
-alicloud_vpc_name = input(:alicloud_vpc_name, value: "", description: "AliCloud VPC name")
-alicloud_vpc_description = input(:alicloud_vpc_description, value: "", description: "AliCloud VPC description")
-alicloud_vpc_cidr = input(:alicloud_vpc_cidr, value: "", description: "AliCloud VPC IPv4 CIDR block")
-alicloud_vpc_vswitch_id = input(:alicloud_vswitch_id, value: "", description: "AliCloud VSwitch ID")
-alicloud_vpc_vrouter_id = input(:alicloud_vrouter_id, value: "", description: "AliCloud VRouter ID")
+title 'Test single AliCloud VPC'
 
-control "alicloud-vpc-1.0" do
+alicloud_vpc_id = input(:alicloud_vpc_id, value: '', description: 'AliCloud VPC ID')
+alicloud_vpc_name = input(:alicloud_vpc_name, value: '', description: 'AliCloud VPC name')
+alicloud_vpc_description = input(:alicloud_vpc_description, value: '', description: 'AliCloud VPC description')
+alicloud_vpc_cidr = input(:alicloud_vpc_cidr, value: '', description: 'AliCloud VPC IPv4 CIDR block')
+alicloud_vpc_vswitch_id = input(:alicloud_vswitch_id, value: '', description: 'AliCloud VSwitch ID')
+alicloud_vpc_vrouter_id = input(:alicloud_vrouter_id, value: '', description: 'AliCloud VRouter ID')
+
+control 'alicloud-vpc-1.0' do
   impact 1.0
-  title "Ensure AliCloud VPC has the correct properties."
+  title 'Ensure AliCloud VPC has the correct properties.'
 
   describe alicloud_vpc(alicloud_vpc_id) do
     it { should exist }
-    its("is_default") { should eq false }
-    its("vpc_name") { should eq alicloud_vpc_name }
-    its("cidr_block") { should eq alicloud_vpc_cidr }
-    its("vswitch_ids") { should include alicloud_vpc_vswitch_id }
-    its("vrouter_id") { should eq alicloud_vpc_vrouter_id }
-    its("status") { should cmp "Available" }
-    its("description") { should eq alicloud_vpc_description }
-    its("cen_attached?") { should eq false }
+    its('is_default') { should eq false }
+    its('vpc_name') { should eq alicloud_vpc_name }
+    its('cidr_block') { should eq alicloud_vpc_cidr }
+    its('vswitch_ids') { should include alicloud_vpc_vswitch_id }
+    its('vrouter_id') { should eq alicloud_vpc_vrouter_id }
+    its('status') { should cmp 'Available' }
+    its('description') { should eq alicloud_vpc_description }
+    its('cen_attached?') { should eq false }
   end
 
-  describe alicloud_vpc(vpc_id: "no-such-vpc") do
+  describe alicloud_vpc(vpc_id: 'no-such-vpc') do
     it { should_not exist }
   end
 end

--- a/test/integration/verify/controls/alicloud_vpcs.rb
+++ b/test/integration/verify/controls/alicloud_vpcs.rb
@@ -1,8 +1,10 @@
-title "Test AliCloud VPC in bulk"
+# frozen_string_literal: true
 
-control "alicloud-vpcs-1.0" do
+title 'Test AliCloud VPC in bulk'
+
+control 'alicloud-vpcs-1.0' do
   impact 1.0
-  title "Ensure AliCloud VPC plural resource has the correct properties."
+  title 'Ensure AliCloud VPC plural resource has the correct properties.'
 
   describe alicloud_vpcs do
     it { should exist }

--- a/test/unit/helper.rb
+++ b/test/unit/helper.rb
@@ -1,10 +1,12 @@
-gem "mocha"
+# frozen_string_literal: true
 
-require "minitest/autorun"
-require "minitest/unit"
-require "minitest/pride"
-require "inspec/resource"
-require "inspec/log"
-require "mocha/minitest"
+gem 'mocha'
+
+require 'minitest/autorun'
+require 'minitest/unit'
+require 'minitest/pride'
+require 'inspec/resource'
+require 'inspec/log'
+require 'mocha/minitest'
 
 Inspec::Log.logger = Logger.new(nil)

--- a/test/unit/resources/alicloud_apsaradb_rds_instance_test.rb
+++ b/test/unit/resources/alicloud_apsaradb_rds_instance_test.rb
@@ -1,19 +1,22 @@
-require "helper"
-require "alicloud_apsaradb_rds_instance"
+# frozen_string_literal: true
+
+require 'helper'
+require 'alicloud_apsaradb_rds_instance'
 
 class AliCloudApsaradbRdsInstanceConstructorTest < Minitest::Test
   def setup
-    ENV["ALICLOUD_REGION"] = "us-east-1"
+    ENV['ALICLOUD_REGION'] = 'us-east-1'
 
-    AliCloudApsaradbRdsInstance.any_instance.stubs(:fetch_db_info).returns({ "DBInstanceMemory" => 1024,
-      "DBInstanceType" => "Primary", "InstanceNetworkType" => "VPC", "DBInstanceId" => "rm-inst4nc3",
-      "DBInstanceStorage" => 20, "Engine" => "MySQL", "DBInstanceDescription" => "testdb",
-      "EngineVersion" => "8.0", "DBInstanceStatus" => "Running", "DBInstanceClass" => "mysql.n1.micro.1",
-      "PayType" => "Postpaid", "VpcId" => "vpc-1234", "Category" => "Basic", "DBInstanceNetType" => "Intranet",
-      "DBInstanceCPU" => "1", "SecurityIPList" => "10.0.0.0/16", "SecurityIPMode" => "normal",
-      "ZoneId" => "eu-west-1a", "DBInstanceStorageType" => "cloud_ssd" })
+    AliCloudApsaradbRdsInstance.any_instance.stubs(:fetch_db_info).returns({ 'DBInstanceMemory' => 1024,
+                                                                             'DBInstanceType' => 'Primary', 'InstanceNetworkType' => 'VPC', 'DBInstanceId' => 'rm-inst4nc3',
+                                                                             'DBInstanceStorage' => 20, 'Engine' => 'MySQL', 'DBInstanceDescription' => 'testdb',
+                                                                             'EngineVersion' => '8.0', 'DBInstanceStatus' => 'Running', 'DBInstanceClass' => 'mysql.n1.micro.1',
+                                                                             'PayType' => 'Postpaid', 'VpcId' => 'vpc-1234', 'Category' => 'Basic', 'DBInstanceNetType' => 'Intranet',
+                                                                             'DBInstanceCPU' => '1', 'SecurityIPList' => '10.0.0.0/16', 'SecurityIPMode' => 'normal',
+                                                                             'ZoneId' => 'eu-west-1a', 'DBInstanceStorageType' => 'cloud_ssd' })
 
-    AliCloudApsaradbRdsInstance.any_instance.stubs(:fetch_vpc_info).returns({ "VpcId" => "vpc-1234", "IsDefault" => false })
+    AliCloudApsaradbRdsInstance.any_instance.stubs(:fetch_vpc_info).returns({ 'VpcId' => 'vpc-1234',
+                                                                              'IsDefault' => false })
   end
 
   def test_empty_params_not_ok
@@ -25,36 +28,36 @@ class AliCloudApsaradbRdsInstanceConstructorTest < Minitest::Test
   end
 
   def test_accepts_string_argument
-    rds = AliCloudApsaradbRdsInstance.new("not-there")
-    assert_equal "not-there", rds.instance_id
+    rds = AliCloudApsaradbRdsInstance.new('not-there')
+    assert_equal 'not-there', rds.instance_id
   end
 
   def test_accepts_key_value_argument_and_resource_works
-    rds = AliCloudApsaradbRdsInstance.new(db_instance_id: "rm-inst4nc3")
-    assert_equal "rm-inst4nc3", rds.instance_id
-    assert_equal "testdb", rds.description
-    assert_equal "Primary", rds.instance_type
-    assert_equal "Basic", rds.category
-    assert_equal "MySQL", rds.engine
-    assert_equal "8.0", rds.engine_version
+    rds = AliCloudApsaradbRdsInstance.new(db_instance_id: 'rm-inst4nc3')
+    assert_equal 'rm-inst4nc3', rds.instance_id
+    assert_equal 'testdb', rds.description
+    assert_equal 'Primary', rds.instance_type
+    assert_equal 'Basic', rds.category
+    assert_equal 'MySQL', rds.engine
+    assert_equal '8.0', rds.engine_version
     assert_equal 20, rds.allocated_storage
-    assert_equal "cloud_ssd", rds.storage_type
+    assert_equal 'cloud_ssd', rds.storage_type
     assert_equal 1024, rds.memory
     assert_equal 1, rds.cpus
-    assert_equal "mysql.n1.micro.1", rds.instance_class
-    assert_equal "Postpaid", rds.pay_type
-    assert_equal "Running", rds.status
-    assert_equal "VPC", rds.network_type
-    assert_equal "Intranet", rds.net_type
-    assert_equal "vpc-1234", rds.vpc_id
-    assert_equal "eu-west-1a", rds.zone_id
+    assert_equal 'mysql.n1.micro.1', rds.instance_class
+    assert_equal 'Postpaid', rds.pay_type
+    assert_equal 'Running', rds.status
+    assert_equal 'VPC', rds.network_type
+    assert_equal 'Intranet', rds.net_type
+    assert_equal 'vpc-1234', rds.vpc_id
+    assert_equal 'eu-west-1a', rds.zone_id
     assert_equal false, rds.in_default_vpc
-    assert_equal "10.0.0.0/16", rds.security_ips
-    assert_equal "normal", rds.security_ip_mode
+    assert_equal '10.0.0.0/16', rds.security_ips
+    assert_equal 'normal', rds.security_ip_mode
   end
 
   def test_accepts_instance_id_and_region
-    rds = AliCloudApsaradbRdsInstance.new(db_instance_id: "rn-inst4nc3", region: "eu-west-1")
-    assert_equal "rn-inst4nc3", rds.instance_id
+    rds = AliCloudApsaradbRdsInstance.new(db_instance_id: 'rn-inst4nc3', region: 'eu-west-1')
+    assert_equal 'rn-inst4nc3', rds.instance_id
   end
 end

--- a/test/unit/resources/alicloud_apsaradb_rds_instances_test.rb
+++ b/test/unit/resources/alicloud_apsaradb_rds_instances_test.rb
@@ -1,21 +1,24 @@
-require "helper"
-require "alicloud_apsaradb_rds_instances"
+# frozen_string_literal: true
+
+require 'helper'
+require 'alicloud_apsaradb_rds_instances'
 
 class AliCloudApsaradbRdsInstancessConstructorTest < Minitest::Test
   def setup
-    ENV["ALICLOUD_REGION"] = "us-east-1"
+    ENV['ALICLOUD_REGION'] = 'us-east-1'
 
-    AliCloudApsaradbRdsInstances.any_instance.stubs(:fetch_data).returns({ "TotalRecordCount" => 1, "PageRecordCount" => 1,
-      "PageNumber" => 1, "Items" => { "DBInstance" => [{ "ResourceGroupId" => "rg-12345", "DBInstanceNetType" => "Intranet",
-      "DBInstanceType" => "Primary", "MutriORsignle" => false, "InstanceNetworkType" => "VPC", "DBInstanceId" => "rm-inst4nc3",
-      "ReadOnlyDBInstanceIds" => { "ReadOnlyDBInstanceId" => [] }, "DBInstanceDescription" => "testdb",
-      "Engine" => "MySQL", "EngineVersion" => "8.0", "DBInstanceStatus" => "Running", "ZoneId" => "eu-west-1a",
-      "DBInstanceClass" => "mysql.n1.micro.1", "CreateTime" => "2021-05-28T08:04:07Z", "VSwitchId" => "vsw-12345",
-      "PayType" => "Postpaid", "LockMode" => "Unlock", "DBInstanceStorageType" => "cloud_ssd", "InsId" => 1,
-      "VpcId" => "vpc-1234", "ConnectionMode" => "Standard", "VpcCloudInstanceId" => "rm-f2z81b1496wwd9393-202105281604",
-      "RegionId" => "eu-west-1", "ExpireTime" => "" }] } })
+    AliCloudApsaradbRdsInstances.any_instance.stubs(:fetch_data).returns({ 'TotalRecordCount' => 1, 'PageRecordCount' => 1,
+                                                                           'PageNumber' => 1, 'Items' => { 'DBInstance' => [{ 'ResourceGroupId' => 'rg-12345', 'DBInstanceNetType' => 'Intranet',
+                                                                                                                              'DBInstanceType' => 'Primary', 'MutriORsignle' => false, 'InstanceNetworkType' => 'VPC', 'DBInstanceId' => 'rm-inst4nc3',
+                                                                                                                              'ReadOnlyDBInstanceIds' => { 'ReadOnlyDBInstanceId' => [] }, 'DBInstanceDescription' => 'testdb',
+                                                                                                                              'Engine' => 'MySQL', 'EngineVersion' => '8.0', 'DBInstanceStatus' => 'Running', 'ZoneId' => 'eu-west-1a',
+                                                                                                                              'DBInstanceClass' => 'mysql.n1.micro.1', 'CreateTime' => '2021-05-28T08:04:07Z', 'VSwitchId' => 'vsw-12345',
+                                                                                                                              'PayType' => 'Postpaid', 'LockMode' => 'Unlock', 'DBInstanceStorageType' => 'cloud_ssd', 'InsId' => 1,
+                                                                                                                              'VpcId' => 'vpc-1234', 'ConnectionMode' => 'Standard', 'VpcCloudInstanceId' => 'rm-f2z81b1496wwd9393-202105281604',
+                                                                                                                              'RegionId' => 'eu-west-1', 'ExpireTime' => '' }] } })
 
-    AliCloudApsaradbRdsInstances.any_instance.stubs(:fetch_vpc_info).returns({ "VpcId" => "vpc-1234", "IsDefault" => false })
+    AliCloudApsaradbRdsInstances.any_instance.stubs(:fetch_vpc_info).returns({ 'VpcId' => 'vpc-1234',
+                                                                               'IsDefault' => false })
   end
 
   def test_rejects_unrecognized_params
@@ -23,34 +26,34 @@ class AliCloudApsaradbRdsInstancessConstructorTest < Minitest::Test
   end
 
   def test_rejects_string_argument
-    assert_raises(ArgumentError) { AliCloudApsaradbRdsInstances.new("not-there") }
+    assert_raises(ArgumentError) { AliCloudApsaradbRdsInstances.new('not-there') }
   end
 
   def test_accepts_no_arguments_and_resource_works
     databases = AliCloudApsaradbRdsInstances.new
-    assert_equal ["rm-inst4nc3"], databases.db_instance_ids
-    assert_equal ["testdb"], databases.descriptions
-    assert_equal ["rg-12345"], databases.resource_groups
-    assert_equal ["Intranet"], databases.net_types
-    assert_equal ["Primary"], databases.instance_types
+    assert_equal ['rm-inst4nc3'], databases.db_instance_ids
+    assert_equal ['testdb'], databases.descriptions
+    assert_equal ['rg-12345'], databases.resource_groups
+    assert_equal ['Intranet'], databases.net_types
+    assert_equal ['Primary'], databases.instance_types
     assert_equal [false], databases.multiple_zone_deployments
-    assert_equal ["VPC"], databases.network_types
+    assert_equal ['VPC'], databases.network_types
     assert_equal [[]], databases.read_only_instance_ids
-    assert_equal ["MySQL"], databases.engines
-    assert_equal ["8.0"], databases.engine_versions
-    assert_equal ["Running"], databases.statuses
-    assert_equal ["eu-west-1a"], databases.zone_ids
-    assert_equal ["mysql.n1.micro.1"], databases.instance_classes
-    assert_equal ["2021-05-28T08:04:07Z"], databases.create_times
-    assert_equal ["vsw-12345"], databases.vswitch_ids
-    assert_equal ["Postpaid"], databases.pay_types
-    assert_equal ["Unlock"], databases.lock_modes
-    assert_equal ["cloud_ssd"], databases.storage_types
-    assert_equal ["vpc-1234"], databases.vpc_ids
+    assert_equal ['MySQL'], databases.engines
+    assert_equal ['8.0'], databases.engine_versions
+    assert_equal ['Running'], databases.statuses
+    assert_equal ['eu-west-1a'], databases.zone_ids
+    assert_equal ['mysql.n1.micro.1'], databases.instance_classes
+    assert_equal ['2021-05-28T08:04:07Z'], databases.create_times
+    assert_equal ['vsw-12345'], databases.vswitch_ids
+    assert_equal ['Postpaid'], databases.pay_types
+    assert_equal ['Unlock'], databases.lock_modes
+    assert_equal ['cloud_ssd'], databases.storage_types
+    assert_equal ['vpc-1234'], databases.vpc_ids
   end
 
   def test_accepts_region
-    databases = AliCloudApsaradbRdsInstances.new(region: "eu-west-1")
-    assert_equal ["rm-inst4nc3"], databases.db_instance_ids
+    databases = AliCloudApsaradbRdsInstances.new(region: 'eu-west-1')
+    assert_equal ['rm-inst4nc3'], databases.db_instance_ids
   end
 end

--- a/test/unit/resources/alicloud_disk_test.rb
+++ b/test/unit/resources/alicloud_disk_test.rb
@@ -1,12 +1,14 @@
-require "helper"
-require "alicloud_disk"
+# frozen_string_literal: true
+
+require 'helper'
+require 'alicloud_disk'
 
 class AliCloudDiskConstructorTest < Minitest::Test
   def setup
-    ENV["ALICLOUD_REGION"] = "us-east-1"
-    AliCloudDisk.any_instance.stubs(:fetch_disk_info).returns({ "Description" => "test disk", "Category" => "cloud_efficiency",
-      "KMSKeyId" => "akey", "Encrypted" => true, "Size" => 20, "DeleteAutoSnapshot" => true, "DeleteWithInstance" => true,
-      "EnableAutoSnapshot" => true, "DiskName" => "my-disk", "DiskId" => "d-123456789" })
+    ENV['ALICLOUD_REGION'] = 'us-east-1'
+    AliCloudDisk.any_instance.stubs(:fetch_disk_info).returns({ 'Description' => 'test disk', 'Category' => 'cloud_efficiency',
+                                                                'KMSKeyId' => 'akey', 'Encrypted' => true, 'Size' => 20, 'DeleteAutoSnapshot' => true, 'DeleteWithInstance' => true,
+                                                                'EnableAutoSnapshot' => true, 'DiskName' => 'my-disk', 'DiskId' => 'd-123456789' })
   end
 
   def test_empty_params_not_ok
@@ -18,22 +20,22 @@ class AliCloudDiskConstructorTest < Minitest::Test
   end
 
   def test_accepts_string_argument
-    disk = AliCloudDisk.new(disk_id: "d-123456789")
-    assert_equal "d-123456789", disk.id
-    assert_equal "my-disk", disk.name
+    disk = AliCloudDisk.new(disk_id: 'd-123456789')
+    assert_equal 'd-123456789', disk.id
+    assert_equal 'my-disk', disk.name
   end
 
   def test_accepts_rejects_string_argument_not_in_disk_id_format
-    assert_raises(ArgumentError) { AliCloudDisk.new("vol-123456789") }
+    assert_raises(ArgumentError) { AliCloudDisk.new('vol-123456789') }
   end
 
   def test_accepts_key_value_disk_id_argument_and_resource_works
-    disk = AliCloudDisk.new(disk_id: "d-123456789")
-    assert_equal "my-disk", disk.name
+    disk = AliCloudDisk.new(disk_id: 'd-123456789')
+    assert_equal 'my-disk', disk.name
     assert_equal true, disk.encrypted
-    assert_equal "test disk", disk.description
-    assert_equal "cloud_efficiency", disk.category
-    assert_equal "akey", disk.kms_key_id
+    assert_equal 'test disk', disk.description
+    assert_equal 'cloud_efficiency', disk.category
+    assert_equal 'akey', disk.kms_key_id
     assert_equal 20, disk.size
     assert_equal true, disk.enable_auto_snapshot
     assert_equal true, disk.delete_auto_snapshot
@@ -41,25 +43,25 @@ class AliCloudDiskConstructorTest < Minitest::Test
   end
 
   def test_accepts_key_value_id_argument
-    disk = AliCloudDisk.new(id: "d-123456789")
-    assert_equal "d-123456789", disk.id
-    assert_equal "my-disk", disk.name
+    disk = AliCloudDisk.new(id: 'd-123456789')
+    assert_equal 'd-123456789', disk.id
+    assert_equal 'my-disk', disk.name
   end
 
   def test_accepts_key_value_disk_name_argument
-    disk = AliCloudDisk.new(disk_name: "my-disk")
-    assert_equal "d-123456789", disk.id
-    assert_equal "my-disk", disk.name
+    disk = AliCloudDisk.new(disk_name: 'my-disk')
+    assert_equal 'd-123456789', disk.id
+    assert_equal 'my-disk', disk.name
   end
 
   def test_accepts_key_value_name_argument
-    disk = AliCloudDisk.new(name: "my-disk")
-    assert_equal "d-123456789", disk.id
-    assert_equal "my-disk", disk.name
+    disk = AliCloudDisk.new(name: 'my-disk')
+    assert_equal 'd-123456789', disk.id
+    assert_equal 'my-disk', disk.name
   end
 
   def test_accepts_disk_id_and_region
-    disk = AliCloudDisk.new(disk_id: "d-123456789", region: "us-east-1")
-    assert_equal "d-123456789", disk.id
+    disk = AliCloudDisk.new(disk_id: 'd-123456789', region: 'us-east-1')
+    assert_equal 'd-123456789', disk.id
   end
 end

--- a/test/unit/resources/alicloud_disks_test.rb
+++ b/test/unit/resources/alicloud_disks_test.rb
@@ -1,18 +1,20 @@
-require "helper"
-require "alicloud_disks"
+# frozen_string_literal: true
+
+require 'helper'
+require 'alicloud_disks'
 
 class AliCloudDisksConstructorTest < Minitest::Test
   def setup
-    ENV["ALICLOUD_REGION"] = "eu-west-1"
-    AliCloudDisks.any_instance.stubs(:fetch_data).returns([{ "Description" => "test disk 1", "Category" => "cloud_efficiency",
-      "KMSKeyId" => "akey", "Encrypted" => true, "Size" => 20, "DeleteAutoSnapshot" => true, "DeleteWithInstance" => false,
-      "EnableAutoSnapshot" => true, "DiskName" => "my-first-disk", "DiskId" => "d-123456789" },
-      { "Description" => "test disk 2", "Category" => "cloud_efficiency",
-      "KMSKeyId" => "bkey", "Encrypted" => true, "Size" => 20, "DeleteAutoSnapshot" => true, "DeleteWithInstance" => false,
-      "EnableAutoSnapshot" => true, "DiskName" => "my-second-disk", "DiskId" => "d-987654321" },
-      { "Description" => "test disk 3", "Category" => "cloud_efficiency",
-      "KMSKeyId" => "ckey", "Encrypted" => false, "Size" => 20, "DeleteAutoSnapshot" => true, "DeleteWithInstance" => false,
-      "EnableAutoSnapshot" => true, "DiskName" => "my-third-disk", "DiskId" => "d-555555555" }])
+    ENV['ALICLOUD_REGION'] = 'eu-west-1'
+    AliCloudDisks.any_instance.stubs(:fetch_data).returns([{ 'Description' => 'test disk 1', 'Category' => 'cloud_efficiency',
+                                                             'KMSKeyId' => 'akey', 'Encrypted' => true, 'Size' => 20, 'DeleteAutoSnapshot' => true, 'DeleteWithInstance' => false,
+                                                             'EnableAutoSnapshot' => true, 'DiskName' => 'my-first-disk', 'DiskId' => 'd-123456789' },
+                                                           { 'Description' => 'test disk 2', 'Category' => 'cloud_efficiency',
+                                                             'KMSKeyId' => 'bkey', 'Encrypted' => true, 'Size' => 20, 'DeleteAutoSnapshot' => true, 'DeleteWithInstance' => false,
+                                                             'EnableAutoSnapshot' => true, 'DiskName' => 'my-second-disk', 'DiskId' => 'd-987654321' },
+                                                           { 'Description' => 'test disk 3', 'Category' => 'cloud_efficiency',
+                                                             'KMSKeyId' => 'ckey', 'Encrypted' => false, 'Size' => 20, 'DeleteAutoSnapshot' => true, 'DeleteWithInstance' => false,
+                                                             'EnableAutoSnapshot' => true, 'DiskName' => 'my-third-disk', 'DiskId' => 'd-555555555' }])
   end
 
   def test_rejects_unrecognized_params
@@ -21,12 +23,12 @@ class AliCloudDisksConstructorTest < Minitest::Test
 
   def test_accepts_no_arguments
     disks = AliCloudDisks.new
-    assert_equal %w{d-123456789 d-987654321 d-555555555}, disks.ids
-    assert_equal ["test disk 1", "test disk 2", "test disk 3"], disks.descriptions
-    assert_equal %w{my-first-disk my-second-disk my-third-disk}, disks.names
+    assert_equal %w[d-123456789 d-987654321 d-555555555], disks.ids
+    assert_equal ['test disk 1', 'test disk 2', 'test disk 3'], disks.descriptions
+    assert_equal %w[my-first-disk my-second-disk my-third-disk], disks.names
     assert_equal [true, true, false], disks.encrypted_disks
-    assert_equal %w{cloud_efficiency cloud_efficiency cloud_efficiency}, disks.categories
-    assert_equal %w{akey bkey ckey}, disks.kms_key_ids
+    assert_equal %w[cloud_efficiency cloud_efficiency cloud_efficiency], disks.categories
+    assert_equal %w[akey bkey ckey], disks.kms_key_ids
     assert_equal [20, 20, 20], disks.sizes
     assert_equal [true, true, true], disks.enable_auto_snapshot
     assert_equal [true, true, true], disks.delete_auto_snapshot
@@ -34,6 +36,6 @@ class AliCloudDisksConstructorTest < Minitest::Test
   end
 
   def test_accepts_region
-    AliCloudDisks.new(region: "us-east-1")
+    AliCloudDisks.new(region: 'us-east-1')
   end
 end

--- a/test/unit/resources/alicloud_disks_test.rb
+++ b/test/unit/resources/alicloud_disks_test.rb
@@ -23,12 +23,12 @@ class AliCloudDisksConstructorTest < Minitest::Test
 
   def test_accepts_no_arguments
     disks = AliCloudDisks.new
-    assert_equal %w[d-123456789 d-987654321 d-555555555], disks.ids
+    assert_equal %w{d-123456789 d-987654321 d-555555555}, disks.ids
     assert_equal ['test disk 1', 'test disk 2', 'test disk 3'], disks.descriptions
-    assert_equal %w[my-first-disk my-second-disk my-third-disk], disks.names
+    assert_equal %w{my-first-disk my-second-disk my-third-disk}, disks.names
     assert_equal [true, true, false], disks.encrypted_disks
-    assert_equal %w[cloud_efficiency cloud_efficiency cloud_efficiency], disks.categories
-    assert_equal %w[akey bkey ckey], disks.kms_key_ids
+    assert_equal %w{cloud_efficiency cloud_efficiency cloud_efficiency}, disks.categories
+    assert_equal %w{akey bkey ckey}, disks.kms_key_ids
     assert_equal [20, 20, 20], disks.sizes
     assert_equal [true, true, true], disks.enable_auto_snapshot
     assert_equal [true, true, true], disks.delete_auto_snapshot

--- a/test/unit/resources/alicloud_ecs_instance_test.rb
+++ b/test/unit/resources/alicloud_ecs_instance_test.rb
@@ -1,25 +1,28 @@
-require "helper"
-require "alicloud_ecs_instance"
+# frozen_string_literal: true
+
+require 'helper'
+require 'alicloud_ecs_instance'
 
 class AliCloudECSInstanceConstructorTest < Minitest::Test
   def setup
-    ENV["ALICLOUD_REGION"] = "eu-west-1"
+    ENV['ALICLOUD_REGION'] = 'eu-west-1'
 
-    AliCloudECSInstance.any_instance.stubs(:fetch_instance_attributes).returns({ "Description" => "host 1", "Memory" => 8192,
-      "InstanceChargeType" => "PostPaid", "Cpu" => 2, "InstanceNetworkType" => "vpc", "PublicIpAddress" => { "IpAddress" => ["192.168.0.1"] },
-      "InnerIpAddress" => { "IpAddress" => [] }, "ExpiredTime" => "2099-12-31T15:59Z", "ImageId" => "ubuntu_18_04_64_20G_alibase_20190624.vhd",
-      "EipAddress" => { "AllocationId" => "", "IpAddress" => "101.101.101.101", "InternetChargeType" => "" }, "InstanceType" => "ecs.g6.large",
-      "HostName" => "host-01", "VlanId" => "", "Status" => "Running", "IoOptimized" => "optimized", "ZoneId" => "eu-west-1a",
-      "InstanceId" => "i-id1234", "ClusterId" => "", "StoppedMode" => "Not-applicable", "DedicatedHostAttribute" => { "DedicatedHostId" => "",
-      "DedicatedHostName" => "host-01" }, "SecurityGroupIds" => { "SecurityGroupId" => ["sg-12345abc"] }, "VpcAttributes" => {
-      "PrivateIpAddress" => { "IpAddress" => ["10.0.1.22"] }, "VpcId" => "vpc-d7o2g7xz", "VSwitchId" => "vsw-d7oop1h",
-      "NatIpAddress" => "" }, "OperationLocks" => { "LockReason" => [] }, "InternetChargeType" => "PayByTraffic",
-      "InstanceName" => "instance-ugxipr", "InternetMaxBandwidthOut" => 10, "InternetMaxBandwidthIn" => 1000,
-      "SerialNumber" => "xxxxx-xxxx-xxxx", "CreationTime" => "2021-05-27T13:48:03Z", "RegionId" => "eu-west-1", "CreditSpecification" => "" })
+    AliCloudECSInstance.any_instance.stubs(:fetch_instance_attributes).returns({ 'Description' => 'host 1', 'Memory' => 8192,
+                                                                                 'InstanceChargeType' => 'PostPaid', 'Cpu' => 2, 'InstanceNetworkType' => 'vpc', 'PublicIpAddress' => { 'IpAddress' => ['192.168.0.1'] },
+                                                                                 'InnerIpAddress' => { 'IpAddress' => [] }, 'ExpiredTime' => '2099-12-31T15:59Z', 'ImageId' => 'ubuntu_18_04_64_20G_alibase_20190624.vhd',
+                                                                                 'EipAddress' => { 'AllocationId' => '', 'IpAddress' => '101.101.101.101', 'InternetChargeType' => '' }, 'InstanceType' => 'ecs.g6.large',
+                                                                                 'HostName' => 'host-01', 'VlanId' => '', 'Status' => 'Running', 'IoOptimized' => 'optimized', 'ZoneId' => 'eu-west-1a',
+                                                                                 'InstanceId' => 'i-id1234', 'ClusterId' => '', 'StoppedMode' => 'Not-applicable', 'DedicatedHostAttribute' => { 'DedicatedHostId' => '',
+                                                                                                                                                                                                 'DedicatedHostName' => 'host-01' }, 'SecurityGroupIds' => { 'SecurityGroupId' => ['sg-12345abc'] }, 'VpcAttributes' => {
+                                                                                                                                                                                                   'PrivateIpAddress' => { 'IpAddress' => ['10.0.1.22'] }, 'VpcId' => 'vpc-d7o2g7xz', 'VSwitchId' => 'vsw-d7oop1h',
+                                                                                                                                                                                                   'NatIpAddress' => ''
+                                                                                                                                                                                                 }, 'OperationLocks' => { 'LockReason' => [] }, 'InternetChargeType' => 'PayByTraffic',
+                                                                                 'InstanceName' => 'instance-ugxipr', 'InternetMaxBandwidthOut' => 10, 'InternetMaxBandwidthIn' => 1000,
+                                                                                 'SerialNumber' => 'xxxxx-xxxx-xxxx', 'CreationTime' => '2021-05-27T13:48:03Z', 'RegionId' => 'eu-west-1', 'CreditSpecification' => '' })
 
-    AliCloudECSInstance.any_instance.stubs(:fetch_instance).returns({ "Instances" => { "Instance" => [{ "DeletionProtection" => true }] } })
+    AliCloudECSInstance.any_instance.stubs(:fetch_instance).returns({ 'Instances' => { 'Instance' => [{ 'DeletionProtection' => true }] } })
 
-    AliCloudECSInstance.any_instance.stubs(:fetch_instance_ram_roles).returns(["test-role-abcdefg"])
+    AliCloudECSInstance.any_instance.stubs(:fetch_instance_ram_roles).returns(['test-role-abcdefg'])
   end
 
   def test_empty_params_not_ok
@@ -31,51 +34,51 @@ class AliCloudECSInstanceConstructorTest < Minitest::Test
   end
 
   def test_accepts_string_argument
-    instance = AliCloudECSInstance.new("i-id1234")
-    assert_equal "i-id1234", instance.instance_id
+    instance = AliCloudECSInstance.new('i-id1234')
+    assert_equal 'i-id1234', instance.instance_id
   end
 
   def test_accepts_key_value_argument_and_resource_works
-    instance = AliCloudECSInstance.new(instance_id: "i-id1234")
-    assert_equal "i-id1234", instance.instance_id
-    assert_equal "host 1", instance.description
+    instance = AliCloudECSInstance.new(instance_id: 'i-id1234')
+    assert_equal 'i-id1234', instance.instance_id
+    assert_equal 'host 1', instance.description
     assert_equal 8192, instance.memory
-    assert_equal "PostPaid", instance.instance_charge_type
+    assert_equal 'PostPaid', instance.instance_charge_type
     assert_equal 2, instance.cpu
-    assert_equal "vpc", instance.instance_network_type
-    assert_equal ["192.168.0.1"], instance.public_ip_address
+    assert_equal 'vpc', instance.instance_network_type
+    assert_equal ['192.168.0.1'], instance.public_ip_address
     assert_equal [], instance.inner_ip_address
-    assert_equal "2099-12-31T15:59Z", instance.expired_time
-    assert_equal "ubuntu_18_04_64_20G_alibase_20190624.vhd", instance.image_id
-    assert_equal "101.101.101.101", instance.eip_address["IpAddress"]
-    assert_equal "ecs.g6.large", instance.instance_type
-    assert_equal "host-01", instance.host_name
-    assert_equal "", instance.vlan_id
-    assert_equal "Running", instance.status
-    assert_equal "optimized", instance.io_optimized
-    assert_equal "eu-west-1a", instance.zone_id
-    assert_equal "", instance.cluster_id
-    assert_equal "Not-applicable", instance.stopped_mode
-    assert_equal "host-01", instance.dedicated_host_attribute["DedicatedHostName"]
-    assert_equal ["sg-12345abc"], instance.security_group_ids["SecurityGroupId"]
-    assert_equal ["10.0.1.22"], instance.vpc_attributes["PrivateIpAddress"]["IpAddress"]
-    assert_equal [], instance.operation_locks["LockReason"]
-    assert_equal "PayByTraffic", instance.internet_charge_type
-    assert_equal "instance-ugxipr", instance.instance_name
+    assert_equal '2099-12-31T15:59Z', instance.expired_time
+    assert_equal 'ubuntu_18_04_64_20G_alibase_20190624.vhd', instance.image_id
+    assert_equal '101.101.101.101', instance.eip_address['IpAddress']
+    assert_equal 'ecs.g6.large', instance.instance_type
+    assert_equal 'host-01', instance.host_name
+    assert_equal '', instance.vlan_id
+    assert_equal 'Running', instance.status
+    assert_equal 'optimized', instance.io_optimized
+    assert_equal 'eu-west-1a', instance.zone_id
+    assert_equal '', instance.cluster_id
+    assert_equal 'Not-applicable', instance.stopped_mode
+    assert_equal 'host-01', instance.dedicated_host_attribute['DedicatedHostName']
+    assert_equal ['sg-12345abc'], instance.security_group_ids['SecurityGroupId']
+    assert_equal ['10.0.1.22'], instance.vpc_attributes['PrivateIpAddress']['IpAddress']
+    assert_equal [], instance.operation_locks['LockReason']
+    assert_equal 'PayByTraffic', instance.internet_charge_type
+    assert_equal 'instance-ugxipr', instance.instance_name
     assert_equal 10, instance.internet_max_bandwidth_out
     assert_equal 1000, instance.internet_max_bandwidth_in
-    assert_equal "xxxxx-xxxx-xxxx", instance.serial_number
+    assert_equal 'xxxxx-xxxx-xxxx', instance.serial_number
 
     # @creation_time              = @instance_attributes["CreationTime"]
     # assert_equal ["2021-05-27T13:48Z"], instances.creation_times
     # @credit_specification       = @instance_attributes["CreditSpecification"]
 
     assert_equal true, instance.deletion_protection
-    assert_equal ["test-role-abcdefg"], instance.ram_roles
+    assert_equal ['test-role-abcdefg'], instance.ram_roles
   end
 
   def test_accepts_instance_id_and_region
-    instance = AliCloudECSInstance.new(instance_id: "i-id1234", region: "eu-west-1")
-    assert_equal "i-id1234", instance.instance_id
+    instance = AliCloudECSInstance.new(instance_id: 'i-id1234', region: 'eu-west-1')
+    assert_equal 'i-id1234', instance.instance_id
   end
 end

--- a/test/unit/resources/alicloud_ecs_instances_test.rb
+++ b/test/unit/resources/alicloud_ecs_instances_test.rb
@@ -1,32 +1,34 @@
-require "helper"
-require "alicloud_ecs_instances"
+# frozen_string_literal: true
+
+require 'helper'
+require 'alicloud_ecs_instances'
 
 class AliCloudECSInstancesConstructorTest < Minitest::Test
   def setup
-    ENV["ALICLOUD_REGION"] = "eu-west-1"
+    ENV['ALICLOUD_REGION'] = 'eu-west-1'
 
-    AliCloudECSInstances.any_instance.stubs(:fetch_data).returns([{ "ResourceGroupId" => "rg-12345", "Memory" => 8192,
-      "InstanceChargeType" => "PostPaid", "Cpu" => 2, "OSName" => "Ubuntu 18.04", "InstanceNetworkType" => "vpc",
-      "InnerIpAddress" => { "IpAddress" => [] }, "ExpiredTime" => "2099-12-31T15:59Z",
-      "ImageId" => "ubuntu_18_04_64_20G_alibase_20190624.vhd", "EipAddress" => { "AllocationId" => "",
-      "IpAddress" => "101.101.101.101", "InternetChargeType" => "" }, "HostName" => "host-01", "VlanId" => "", "Status" => "Running",
-      "MetadataOptions" => { "HttpTokens" => "optimal", "HttpEndpoint" => "" }, "InstanceId" => "i-id1234",
-      "StoppedMode" => "Not-applicable", "CpuOptions" => { "ThreadsPerCore" => 2, "Numa" => "ON", "CoreCount" => 1 },
-      "StartTime" => "2021-05-27T13:48Z", "DeletionProtection" => true, "SecurityGroupIds" => { "SecurityGroupId" => ["sg-12345abc"] },
-      "VpcAttributes" => { "PrivateIpAddress" => { "IpAddress" => ["10.0.1.22"] }, "VpcId" => "vpc-d7o2g7xz9javyxyke96w3",
-      "VSwitchId" => "vsw-d7oop1hf6cxg65343zi7s", "NatIpAddress" => "" }, "InternetChargeType" => "PayByTraffic",
-      "InstanceName" => "instance-ugxipr", "DeploymentSetId" => "ds0bp67ax", "InternetMaxBandwidthOut" => 10,
-      "InternetMaxBandwidthIn" => 10, "SerialNumber" => "xxxxx-xxxx-xxxx", "OSType" => "linux", "CreationTime" => "2021-05-27T13:48Z",
-      "AutoReleaseTime" => "", "Description" => "host 1", "InstanceTypeFamily" => "ecs.g6", "DedicatedInstanceAttribute" =>
-      { "Tenancy" => "", "Affinity" => "" }, "PublicIpAddress" => { "IpAddress" => ["100.100.100.100"] },
-      "GPUSpec" => "NVIDIA V100", "NetworkInterfaces" => { "NetworkInterface" => [{ "Type" => "Primary",
-      "PrimaryIpAddress" => "10.0.1.22", "MacAddress" => "00:16:3e:01:51:05", "NetworkInterfaceId" =>
-      "eni-d7oaidufeql94hm6wxqj", "PrivateIpSets" => { "PrivateIpSet" => [{ "PrivateIpAddress" => "10.0.1.22",
-      "Primary" => true }] } }] }, "SpotPriceLimit" => 0.0, "DeviceAvailable" => true, "SaleCycle" => "month",
-      "InstanceType" => "ecs.g6.large", "SpotStrategy" => "NoSpot", "OSNameEn" => "Ubuntu 18.04 64 bit",
-      "IoOptimized" => true, "ZoneId" => "eu-west-1a", "GPUAmount" => 0 }])
+    AliCloudECSInstances.any_instance.stubs(:fetch_data).returns([{ 'ResourceGroupId' => 'rg-12345', 'Memory' => 8192,
+                                                                    'InstanceChargeType' => 'PostPaid', 'Cpu' => 2, 'OSName' => 'Ubuntu 18.04', 'InstanceNetworkType' => 'vpc',
+                                                                    'InnerIpAddress' => { 'IpAddress' => [] }, 'ExpiredTime' => '2099-12-31T15:59Z',
+                                                                    'ImageId' => 'ubuntu_18_04_64_20G_alibase_20190624.vhd', 'EipAddress' => { 'AllocationId' => '',
+                                                                                                                                               'IpAddress' => '101.101.101.101', 'InternetChargeType' => '' }, 'HostName' => 'host-01', 'VlanId' => '', 'Status' => 'Running',
+                                                                    'MetadataOptions' => { 'HttpTokens' => 'optimal', 'HttpEndpoint' => '' }, 'InstanceId' => 'i-id1234',
+                                                                    'StoppedMode' => 'Not-applicable', 'CpuOptions' => { 'ThreadsPerCore' => 2, 'Numa' => 'ON', 'CoreCount' => 1 },
+                                                                    'StartTime' => '2021-05-27T13:48Z', 'DeletionProtection' => true, 'SecurityGroupIds' => { 'SecurityGroupId' => ['sg-12345abc'] },
+                                                                    'VpcAttributes' => { 'PrivateIpAddress' => { 'IpAddress' => ['10.0.1.22'] }, 'VpcId' => 'vpc-d7o2g7xz9javyxyke96w3',
+                                                                                         'VSwitchId' => 'vsw-d7oop1hf6cxg65343zi7s', 'NatIpAddress' => '' }, 'InternetChargeType' => 'PayByTraffic',
+                                                                    'InstanceName' => 'instance-ugxipr', 'DeploymentSetId' => 'ds0bp67ax', 'InternetMaxBandwidthOut' => 10,
+                                                                    'InternetMaxBandwidthIn' => 10, 'SerialNumber' => 'xxxxx-xxxx-xxxx', 'OSType' => 'linux', 'CreationTime' => '2021-05-27T13:48Z',
+                                                                    'AutoReleaseTime' => '', 'Description' => 'host 1', 'InstanceTypeFamily' => 'ecs.g6', 'DedicatedInstanceAttribute' =>
+      { 'Tenancy' => '', 'Affinity' => '' }, 'PublicIpAddress' => { 'IpAddress' => ['100.100.100.100'] },
+                                                                    'GPUSpec' => 'NVIDIA V100', 'NetworkInterfaces' => { 'NetworkInterface' => [{ 'Type' => 'Primary',
+                                                                                                                                                  'PrimaryIpAddress' => '10.0.1.22', 'MacAddress' => '00:16:3e:01:51:05', 'NetworkInterfaceId' =>
+      'eni-d7oaidufeql94hm6wxqj', 'PrivateIpSets' => { 'PrivateIpSet' => [{ 'PrivateIpAddress' => '10.0.1.22',
+                                                                            'Primary' => true }] } }] }, 'SpotPriceLimit' => 0.0, 'DeviceAvailable' => true, 'SaleCycle' => 'month',
+                                                                    'InstanceType' => 'ecs.g6.large', 'SpotStrategy' => 'NoSpot', 'OSNameEn' => 'Ubuntu 18.04 64 bit',
+                                                                    'IoOptimized' => true, 'ZoneId' => 'eu-west-1a', 'GPUAmount' => 0 }])
 
-    AliCloudECSInstances.any_instance.stubs(:fetch_instance_ram_roles).returns(["test-role-abcdefg"])
+    AliCloudECSInstances.any_instance.stubs(:fetch_instance_ram_roles).returns(['test-role-abcdefg'])
   end
 
   def test_rejects_unrecognized_params
@@ -34,59 +36,59 @@ class AliCloudECSInstancesConstructorTest < Minitest::Test
   end
 
   def test_does_not_accept_string_argument
-    assert_raises(ArgumentError) { AliCloudECSInstances.new("i-id1234") }
+    assert_raises(ArgumentError) { AliCloudECSInstances.new('i-id1234') }
   end
 
   def test_resource_works_with_no_params
     instances = AliCloudECSInstances.new
-    assert_equal ["i-id1234"], instances.instance_ids
-    assert_equal ["instance-ugxipr"], instances.instance_names
-    assert_equal ["host-01"], instances.host_names
-    assert_equal ["host 1"], instances.descriptions
+    assert_equal ['i-id1234'], instances.instance_ids
+    assert_equal ['instance-ugxipr'], instances.instance_names
+    assert_equal ['host-01'], instances.host_names
+    assert_equal ['host 1'], instances.descriptions
     assert_equal [8192], instances.memory
-    assert_equal ["PostPaid"], instances.instance_charge_types
+    assert_equal ['PostPaid'], instances.instance_charge_types
     assert_equal [2], instances.cpus
-    assert_equal ["Ubuntu 18.04"], instances.os_names
-    assert_equal ["vpc"], instances.instance_network_types
+    assert_equal ['Ubuntu 18.04'], instances.os_names
+    assert_equal ['vpc'], instances.instance_network_types
     assert_equal [[]], instances.inner_ip_addresses
-    assert_equal ["2099-12-31T15:59Z"], instances.expired_times
-    assert_equal ["ubuntu_18_04_64_20G_alibase_20190624.vhd"], instances.image_ids
-    assert_equal "101.101.101.101", instances.eip_addresses.first["IpAddress"]
-    assert_equal [""], instances.vlan_ids
-    assert_equal ["Running"], instances.statuses
+    assert_equal ['2099-12-31T15:59Z'], instances.expired_times
+    assert_equal ['ubuntu_18_04_64_20G_alibase_20190624.vhd'], instances.image_ids
+    assert_equal '101.101.101.101', instances.eip_addresses.first['IpAddress']
+    assert_equal [''], instances.vlan_ids
+    assert_equal ['Running'], instances.statuses
     assert_equal [true], instances.io_optimized
-    assert_equal "optimal", instances.metadata_options.first["HttpTokens"]
-    assert_equal ["eu-west-1a"], instances.zone_ids
-    assert_equal ["Not-applicable"], instances.stopped_modes
-    assert_equal 1, instances.cpu_options.first["CoreCount"]
-    assert_equal ["2021-05-27T13:48Z"], instances.start_times
-    assert_equal ["sg-12345abc"], instances.security_group_ids.first["SecurityGroupId"]
-    assert_equal ["10.0.1.22"], instances.vpc_attributes.first["PrivateIpAddress"]["IpAddress"]
-    assert_equal ["PayByTraffic"], instances.internet_charge_types
-    assert_equal ["ds0bp67ax"], instances.deployment_set_ids
+    assert_equal 'optimal', instances.metadata_options.first['HttpTokens']
+    assert_equal ['eu-west-1a'], instances.zone_ids
+    assert_equal ['Not-applicable'], instances.stopped_modes
+    assert_equal 1, instances.cpu_options.first['CoreCount']
+    assert_equal ['2021-05-27T13:48Z'], instances.start_times
+    assert_equal ['sg-12345abc'], instances.security_group_ids.first['SecurityGroupId']
+    assert_equal ['10.0.1.22'], instances.vpc_attributes.first['PrivateIpAddress']['IpAddress']
+    assert_equal ['PayByTraffic'], instances.internet_charge_types
+    assert_equal ['ds0bp67ax'], instances.deployment_set_ids
     assert_equal [10], instances.internet_max_bandwidth_in
     assert_equal [10], instances.internet_max_bandwidth_out
-    assert_equal ["xxxxx-xxxx-xxxx"], instances.serial_numbers
-    assert_equal ["linux"], instances.os_types
-    assert_equal ["2021-05-27T13:48Z"], instances.creation_times
-    assert_equal [""], instances.auto_release_times
-    assert_equal ["ecs.g6"], instances.instance_type_families
-    assert_equal "", instances.dedicated_instance_attributes.first["Tenancy"]
-    assert_equal ["100.100.100.100"], instances.public_ip_addresses.first["IpAddress"]
-    assert_equal ["NVIDIA V100"], instances.gpu_specs
-    assert_equal "10.0.1.22", instances.network_interfaces.first["NetworkInterface"].first["PrimaryIpAddress"]
+    assert_equal ['xxxxx-xxxx-xxxx'], instances.serial_numbers
+    assert_equal ['linux'], instances.os_types
+    assert_equal ['2021-05-27T13:48Z'], instances.creation_times
+    assert_equal [''], instances.auto_release_times
+    assert_equal ['ecs.g6'], instances.instance_type_families
+    assert_equal '', instances.dedicated_instance_attributes.first['Tenancy']
+    assert_equal ['100.100.100.100'], instances.public_ip_addresses.first['IpAddress']
+    assert_equal ['NVIDIA V100'], instances.gpu_specs
+    assert_equal '10.0.1.22', instances.network_interfaces.first['NetworkInterface'].first['PrimaryIpAddress']
     assert_equal [0.0], instances.spot_price_limits
     assert_equal [true], instances.devices_available
-    assert_equal ["month"], instances.sale_cycles
-    assert_equal ["ecs.g6.large"], instances.instance_types
-    assert_equal ["Ubuntu 18.04 64 bit"], instances.os_names_en
-    assert_equal ["NoSpot"], instances.spot_strategies
+    assert_equal ['month'], instances.sale_cycles
+    assert_equal ['ecs.g6.large'], instances.instance_types
+    assert_equal ['Ubuntu 18.04 64 bit'], instances.os_names_en
+    assert_equal ['NoSpot'], instances.spot_strategies
     assert_equal [true], instances.deletion_protections
-    assert_equal [["test-role-abcdefg"]], instances.ram_roles
+    assert_equal [['test-role-abcdefg']], instances.ram_roles
   end
 
   def test_accepts_region
-    instances = AliCloudECSInstances.new(region: "eu-west-1")
-    assert_equal ["i-id1234"], instances.instance_ids
+    instances = AliCloudECSInstances.new(region: 'eu-west-1')
+    assert_equal ['i-id1234'], instances.instance_ids
   end
 end

--- a/test/unit/resources/alicloud_ram_policies_test.rb
+++ b/test/unit/resources/alicloud_ram_policies_test.rb
@@ -1,33 +1,42 @@
-require "helper"
-require "alicloud_ram_policies"
+# frozen_string_literal: true
+
+require 'helper'
+require 'alicloud_ram_policies'
 
 class AliCloudRamPoliciesConstructorTest < Minitest::Test
   def setup
-    ENV["ALICLOUD_REGION"] = "us-east-1"
+    ENV['ALICLOUD_REGION'] = 'us-east-1'
 
-    system = { "Policies" => { "Policy" => [{ "PolicyType" => "System", "Description" => "System test policy 1",
-      "AttachmentCount" => 0, "PolicyName" => "system-test-1", "DefaultVersion" => "v1" },
-      { "PolicyType" => "System", "Description" => "System test policy 2", "AttachmentCount" => 1,
-      "PolicyName" => "system-test-2", "DefaultVersion" => "v2" }, { "PolicyType" => "System",
-      "Description" => "System test policy 3", "AttachmentCount" => 0, "PolicyName" => "system-test-3",
-      "DefaultVersion" => "v1" }] }, "IsTruncated" => false }
-    custom = { "Policies" => { "Policy" => [{ "PolicyType" => "Custom", "Description" => "Test policy 1",
-      "AttachmentCount" => 1, "PolicyName" => "test-1", "DefaultVersion" => "v3" }, { "PolicyType" => "Custom",
-      "Description" => "Test policy 2", "AttachmentCount" => 0, "PolicyName" => "test-2", "DefaultVersion" => "v2" },
-      { "PolicyType" => "Custom", "Description" => "Test policy 3", "AttachmentCount" => 0, "PolicyName" => "test-3",
-      "DefaultVersion" => "v4" }] }, "IsTruncated" => false }
+    system = { 'Policies' => { 'Policy' => [{ 'PolicyType' => 'System', 'Description' => 'System test policy 1',
+                                              'AttachmentCount' => 0, 'PolicyName' => 'system-test-1', 'DefaultVersion' => 'v1' },
+                                            { 'PolicyType' => 'System', 'Description' => 'System test policy 2', 'AttachmentCount' => 1,
+                                              'PolicyName' => 'system-test-2', 'DefaultVersion' => 'v2' }, { 'PolicyType' => 'System',
+                                                                                                             'Description' => 'System test policy 3', 'AttachmentCount' => 0, 'PolicyName' => 'system-test-3',
+                                                                                                             'DefaultVersion' => 'v1' }] }, 'IsTruncated' => false }
+    custom = { 'Policies' => { 'Policy' => [{ 'PolicyType' => 'Custom', 'Description' => 'Test policy 1',
+                                              'AttachmentCount' => 1, 'PolicyName' => 'test-1', 'DefaultVersion' => 'v3' }, { 'PolicyType' => 'Custom',
+                                                                                                                              'Description' => 'Test policy 2', 'AttachmentCount' => 0, 'PolicyName' => 'test-2', 'DefaultVersion' => 'v2' },
+                                            { 'PolicyType' => 'Custom', 'Description' => 'Test policy 3', 'AttachmentCount' => 0, 'PolicyName' => 'test-3',
+                                              'DefaultVersion' => 'v4' }] }, 'IsTruncated' => false }
 
-    AliCloudRamPolicies.any_instance.stubs(:list_policies).with(type: "System", region: "us-east-1").returns(system)
-    AliCloudRamPolicies.any_instance.stubs(:list_policies).with(type: "Custom", region: "us-east-1").returns(custom)
-    AliCloudRamPolicies.any_instance.stubs(:list_policies).with(only_attached: true, region: "us-east-1", type: "System").returns(system)
-    AliCloudRamPolicies.any_instance.stubs(:list_policies).with(only_attached: true, region: "us-east-1", type: "Custom").returns(custom)
-    AliCloudRamPolicies.any_instance.stubs(:list_policies).with(type: "System", region: "eu-west-1").returns(system)
+    AliCloudRamPolicies.any_instance.stubs(:list_policies).with(type: 'System', region: 'us-east-1').returns(system)
+    AliCloudRamPolicies.any_instance.stubs(:list_policies).with(type: 'Custom', region: 'us-east-1').returns(custom)
+    AliCloudRamPolicies.any_instance.stubs(:list_policies).with(only_attached: true, region: 'us-east-1',
+                                                                type: 'System').returns(system)
+    AliCloudRamPolicies.any_instance.stubs(:list_policies).with(only_attached: true, region: 'us-east-1',
+                                                                type: 'Custom').returns(custom)
+    AliCloudRamPolicies.any_instance.stubs(:list_policies).with(type: 'System', region: 'eu-west-1').returns(system)
 
     AliCloudRamPolicies.any_instance.stubs(:get_attached_entities).returns({
-     "Groups" => { "Group" => [{ "GroupName" => "group-1", "AttachDate" => "2021-01-01T00:00:00Z", "Comments" => "A comment" }] },
-     "Roles" => { "Role" => [{ "RoleName" => "role-1", "Description" => "", "Arn" => "acs:ram::12345:role/role-1", "RoleId" => "55555" }] },
-     "Users" => { "User" => [{ "UserName" => "user-1", "UserId" => "66666", "DisplayName" => "user-1" },
-                        { "UserName" => "user-2", "UserId" => "88888", "DisplayName" => "user-2" }] } })
+                                                                             'Groups' => { 'Group' => [{ 'GroupName' => 'group-1', 'AttachDate' => '2021-01-01T00:00:00Z',
+                                                                                                         'Comments' => 'A comment' }] },
+                                                                             'Roles' => { 'Role' => [{ 'RoleName' => 'role-1', 'Description' => '', 'Arn' => 'acs:ram::12345:role/role-1',
+                                                                                                       'RoleId' => '55555' }] },
+                                                                             'Users' => { 'User' => [{ 'UserName' => 'user-1', 'UserId' => '66666', 'DisplayName' => 'user-1' },
+                                                                                                     {
+                                                                                                       'UserName' => 'user-2', 'UserId' => '88888', 'DisplayName' => 'user-2'
+                                                                                                     }] }
+                                                                           })
   end
 
   def test_rejects_unrecognized_params
@@ -36,33 +45,33 @@ class AliCloudRamPoliciesConstructorTest < Minitest::Test
 
   def test_accepts_no_arguments
     policies = AliCloudRamPolicies.new
-    assert_equal %w{system-test-1 system-test-2 system-test-3 test-1 test-2 test-3}, policies.policy_names
-    assert_equal %w{v1 v2 v1 v3 v2 v4}, policies.default_versions
+    assert_equal %w[system-test-1 system-test-2 system-test-3 test-1 test-2 test-3], policies.policy_names
+    assert_equal %w[v1 v2 v1 v3 v2 v4], policies.default_versions
     assert_equal [0, 1, 0, 1, 0, 0], policies.attachment_counts
-    assert_equal [[], ["group-1"], [], ["group-1"], [], []], policies.attached_groups
-    assert_equal [[], ["role-1"], [], ["role-1"], [], []], policies.attached_roles
-    assert_equal [[], %w{user-1 user-2}, [], %w{user-1 user-2}, [], []], policies.attached_users
+    assert_equal [[], ['group-1'], [], ['group-1'], [], []], policies.attached_groups
+    assert_equal [[], ['role-1'], [], ['role-1'], [], []], policies.attached_roles
+    assert_equal [[], %w[user-1 user-2], [], %w[user-1 user-2], [], []], policies.attached_users
   end
 
   def test_accepts_custom_as_string_argument
-    policies = AliCloudRamPolicies.new("Custom")
-    assert_equal %w{test-1 test-2 test-3}, policies.policy_names
-    assert_equal %w{v3 v2 v4}, policies.default_versions
-    assert_equal [["group-1"], [], []], policies.attached_groups
-    assert_equal [["role-1"], [], []], policies.attached_roles
-    assert_equal [%w{user-1 user-2}, [], []], policies.attached_users
+    policies = AliCloudRamPolicies.new('Custom')
+    assert_equal %w[test-1 test-2 test-3], policies.policy_names
+    assert_equal %w[v3 v2 v4], policies.default_versions
+    assert_equal [['group-1'], [], []], policies.attached_groups
+    assert_equal [['role-1'], [], []], policies.attached_roles
+    assert_equal [%w[user-1 user-2], [], []], policies.attached_users
   end
 
   def test_accepts_system_type_and_region
-    policies = AliCloudRamPolicies.new(type: "System", region: "eu-west-1")
-    assert_equal %w{system-test-1 system-test-2 system-test-3}, policies.policy_names
-    assert_equal %w{v1 v2 v1}, policies.default_versions
+    policies = AliCloudRamPolicies.new(type: 'System', region: 'eu-west-1')
+    assert_equal %w[system-test-1 system-test-2 system-test-3], policies.policy_names
+    assert_equal %w[v1 v2 v1], policies.default_versions
   end
 
   def test_only_attached
     policies = AliCloudRamPolicies.new(only_attached: true)
-    assert_equal %w{system-test-2 test-1}, policies.policy_names
-    assert_equal %w{v2 v3}, policies.default_versions
+    assert_equal %w[system-test-2 test-1], policies.policy_names
+    assert_equal %w[v2 v3], policies.default_versions
     assert_equal [1, 1], policies.attachment_counts
   end
 end

--- a/test/unit/resources/alicloud_ram_policies_test.rb
+++ b/test/unit/resources/alicloud_ram_policies_test.rb
@@ -35,7 +35,7 @@ class AliCloudRamPoliciesConstructorTest < Minitest::Test
                                                                              'Users' => { 'User' => [{ 'UserName' => 'user-1', 'UserId' => '66666', 'DisplayName' => 'user-1' },
                                                                                                      {
                                                                                                        'UserName' => 'user-2', 'UserId' => '88888', 'DisplayName' => 'user-2'
-                                                                                                     }] }
+                                                                                                     }] },
                                                                            })
   end
 
@@ -45,33 +45,33 @@ class AliCloudRamPoliciesConstructorTest < Minitest::Test
 
   def test_accepts_no_arguments
     policies = AliCloudRamPolicies.new
-    assert_equal %w[system-test-1 system-test-2 system-test-3 test-1 test-2 test-3], policies.policy_names
-    assert_equal %w[v1 v2 v1 v3 v2 v4], policies.default_versions
+    assert_equal %w{system-test-1 system-test-2 system-test-3 test-1 test-2 test-3}, policies.policy_names
+    assert_equal %w{v1 v2 v1 v3 v2 v4}, policies.default_versions
     assert_equal [0, 1, 0, 1, 0, 0], policies.attachment_counts
     assert_equal [[], ['group-1'], [], ['group-1'], [], []], policies.attached_groups
     assert_equal [[], ['role-1'], [], ['role-1'], [], []], policies.attached_roles
-    assert_equal [[], %w[user-1 user-2], [], %w[user-1 user-2], [], []], policies.attached_users
+    assert_equal [[], %w{user-1 user-2}, [], %w{user-1 user-2}, [], []], policies.attached_users
   end
 
   def test_accepts_custom_as_string_argument
     policies = AliCloudRamPolicies.new('Custom')
-    assert_equal %w[test-1 test-2 test-3], policies.policy_names
-    assert_equal %w[v3 v2 v4], policies.default_versions
+    assert_equal %w{test-1 test-2 test-3}, policies.policy_names
+    assert_equal %w{v3 v2 v4}, policies.default_versions
     assert_equal [['group-1'], [], []], policies.attached_groups
     assert_equal [['role-1'], [], []], policies.attached_roles
-    assert_equal [%w[user-1 user-2], [], []], policies.attached_users
+    assert_equal [%w{user-1 user-2}, [], []], policies.attached_users
   end
 
   def test_accepts_system_type_and_region
     policies = AliCloudRamPolicies.new(type: 'System', region: 'eu-west-1')
-    assert_equal %w[system-test-1 system-test-2 system-test-3], policies.policy_names
-    assert_equal %w[v1 v2 v1], policies.default_versions
+    assert_equal %w{system-test-1 system-test-2 system-test-3}, policies.policy_names
+    assert_equal %w{v1 v2 v1}, policies.default_versions
   end
 
   def test_only_attached
     policies = AliCloudRamPolicies.new(only_attached: true)
-    assert_equal %w[system-test-2 test-1], policies.policy_names
-    assert_equal %w[v2 v3], policies.default_versions
+    assert_equal %w{system-test-2 test-1}, policies.policy_names
+    assert_equal %w{v2 v3}, policies.default_versions
     assert_equal [1, 1], policies.attachment_counts
   end
 end

--- a/test/unit/resources/alicloud_ram_policy_test.rb
+++ b/test/unit/resources/alicloud_ram_policy_test.rb
@@ -41,7 +41,7 @@ class AliCloudRamPolicyConstructorTest < Minitest::Test
                                                                            'Users' => { 'User' => [{ 'UserName' => 'user-1', 'UserId' => '66666', 'DisplayName' => 'user-1' },
                                                                                                    {
                                                                                                      'UserName' => 'user-2', 'UserId' => '88888', 'DisplayName' => 'user-2'
-                                                                                                   }] }
+                                                                                                   }] },
                                                                          })
   end
 

--- a/test/unit/resources/alicloud_ram_policy_test.rb
+++ b/test/unit/resources/alicloud_ram_policy_test.rb
@@ -1,16 +1,18 @@
-require "helper"
-require "alicloud_ram_policy"
+# frozen_string_literal: true
+
+require 'helper'
+require 'alicloud_ram_policy'
 
 class AliCloudRamPolicyConstructorTest < Minitest::Test
   def setup
-    ENV["ALICLOUD_REGION"] = "us-east-1"
+    ENV['ALICLOUD_REGION'] = 'us-east-1'
 
-    AliCloudRamPolicy.any_instance.stubs(:get_policy).returns({ "Policy" => { "PolicyType" => "Custom",
-      "Description" => "Test policy", "AttachmentCount" => 0, "PolicyName" => "test-policy", "DefaultVersion" => "v2" },
-      "DefaultPolicyVersion" => { "VersionId" => "v1", "IsDefaultVersion" => true,
-      "PolicyDocument" => "{\n  \"Version\": \"1\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ecs:Describe*\"\n      ],\n" +
-      "      \"Effect\": \"Allow\",\n      \"Resource\": \"*\"\n    },\n    {\n      \"NotAction\": \"oss:DeleteBucket\",\n" +
-      "      \"Effect\": \"Allow\",\n      \"Resource\": \"acs:oss:::*\"\n    }\n  ]\n}\n", "CreateDate" => "2021-01-01T00:00:00Z" } })
+    AliCloudRamPolicy.any_instance.stubs(:get_policy).returns({ 'Policy' => { 'PolicyType' => 'Custom',
+                                                                              'Description' => 'Test policy', 'AttachmentCount' => 0, 'PolicyName' => 'test-policy', 'DefaultVersion' => 'v2' },
+                                                                'DefaultPolicyVersion' => { 'VersionId' => 'v1', 'IsDefaultVersion' => true,
+                                                                                            'PolicyDocument' => "{\n  \"Version\": \"1\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ecs:Describe*\"\n      ],\n" \
+      "      \"Effect\": \"Allow\",\n      \"Resource\": \"*\"\n    },\n    {\n      \"NotAction\": \"oss:DeleteBucket\",\n" \
+      "      \"Effect\": \"Allow\",\n      \"Resource\": \"acs:oss:::*\"\n    }\n  ]\n}\n", 'CreateDate' => '2021-01-01T00:00:00Z' } })
 
     @policy_document = '{
   "Version": "1",
@@ -31,10 +33,16 @@ class AliCloudRamPolicyConstructorTest < Minitest::Test
 }
 '
     AliCloudRamPolicy.any_instance.stubs(:get_attached_entities).returns({
-     "Groups" => { "Group" => [{ "GroupName" => "group-1", "Comments" => "A comment" }] },
-     "Roles" => { "Role" => [{ "RoleName" => "role-1", "Description" => "", "Arn" => "acs:ram::12345:role/role-1", "RoleId" => "55555" }] },
-     "Users" => { "User" => [{ "UserName" => "user-1", "UserId" => "66666", "DisplayName" => "user-1" },
-                             { "UserName" => "user-2", "UserId" => "88888", "DisplayName" => "user-2" }] } })
+                                                                           'Groups' => { 'Group' => [{
+                                                                             'GroupName' => 'group-1', 'Comments' => 'A comment'
+                                                                           }] },
+                                                                           'Roles' => { 'Role' => [{ 'RoleName' => 'role-1', 'Description' => '', 'Arn' => 'acs:ram::12345:role/role-1',
+                                                                                                     'RoleId' => '55555' }] },
+                                                                           'Users' => { 'User' => [{ 'UserName' => 'user-1', 'UserId' => '66666', 'DisplayName' => 'user-1' },
+                                                                                                   {
+                                                                                                     'UserName' => 'user-2', 'UserId' => '88888', 'DisplayName' => 'user-2'
+                                                                                                   }] }
+                                                                         })
   end
 
   def test_empty_params_not_ok
@@ -46,47 +54,52 @@ class AliCloudRamPolicyConstructorTest < Minitest::Test
   end
 
   def test_accepts_string_argument
-    policy = AliCloudRamPolicy.new("atestpolicy")
-    assert_equal "atestpolicy", policy.policy_name
+    policy = AliCloudRamPolicy.new('atestpolicy')
+    assert_equal 'atestpolicy', policy.policy_name
   end
 
   def test_accepts_key_value_argument_and_resource_works
-    policy = AliCloudRamPolicy.new(policy_name: "atestpolicy")
-    assert_equal "atestpolicy", policy.policy_name
-    assert_equal "v2", policy.default_version
+    policy = AliCloudRamPolicy.new(policy_name: 'atestpolicy')
+    assert_equal 'atestpolicy', policy.policy_name
+    assert_equal 'v2', policy.default_version
     assert_equal @policy_document, policy.policy_document
-    assert_equal true, policy.has_statement?({ Effect: "Allow", Resource: "acs:oss:::*", NotAction: "oss:DeleteBucket" })
-    assert_equal true, policy.has_statement?({ 'Effect': "Allow", 'Resource': "acs:oss:::*", 'NotAction': "oss:DeleteBucket" })
-    assert_equal true, policy.has_statement?({ 'effect': "Allow", 'resource': "acs:oss:::*", 'notaction': "oss:DeleteBucket" })
+    assert_equal true,
+                 policy.has_statement?({ Effect: 'Allow', Resource: 'acs:oss:::*', NotAction: 'oss:DeleteBucket' })
+    assert_equal true,
+                 policy.has_statement?({ 'Effect': 'Allow', 'Resource': 'acs:oss:::*',
+                                         'NotAction': 'oss:DeleteBucket' })
+    assert_equal true,
+                 policy.has_statement?({ 'effect': 'Allow', 'resource': 'acs:oss:::*',
+                                         'notaction': 'oss:DeleteBucket' })
     assert_equal 2, policy.statement_count
-    assert_equal true, policy.attached_to_user?("user-2")
+    assert_equal true, policy.attached_to_user?('user-2')
     assert_equal 2, policy.attached_user_count
-    assert_equal true, policy.attached_to_group?("group-1")
+    assert_equal true, policy.attached_to_group?('group-1')
     assert_equal 1, policy.attached_group_count
-    assert_equal true, policy.attached_to_role?("acs:ram::12345:role/role-1")
+    assert_equal true, policy.attached_to_role?('acs:ram::12345:role/role-1')
     assert_equal 1, policy.attached_role_count
     assert_equal 4, policy.attachment_count
     assert_equal true, policy.attached?
   end
 
   def test_accepts_policy_name_and_region
-    policy = AliCloudRamPolicy.new(policy_name: "atestpolicy", region: "eu-west-1")
-    assert_equal "atestpolicy", policy.policy_name
+    policy = AliCloudRamPolicy.new(policy_name: 'atestpolicy', region: 'eu-west-1')
+    assert_equal 'atestpolicy', policy.policy_name
   end
 
   def test_accepts_policy_name_and_custom_type
-    policy = AliCloudRamPolicy.new(policy_name: "atestpolicy", type: "Custom")
-    assert_equal "v2", policy.default_version
+    policy = AliCloudRamPolicy.new(policy_name: 'atestpolicy', type: 'Custom')
+    assert_equal 'v2', policy.default_version
   end
 
   def test_accepts_policy_name_and_system_type
-    policy = AliCloudRamPolicy.new(policy_name: "atestpolicy", type: "System")
+    policy = AliCloudRamPolicy.new(policy_name: 'atestpolicy', type: 'System')
     assert_equal @policy_document, policy.policy_document
   end
 
   def test_not_attached
     AliCloudRamPolicy.any_instance.stubs(:get_attached_entities).returns(nil)
-    policy = AliCloudRamPolicy.new(policy_name: "atestpolicy")
+    policy = AliCloudRamPolicy.new(policy_name: 'atestpolicy')
     assert_equal 0, policy.attachment_count
   end
 end

--- a/test/unit/resources/alicloud_ram_user_mfa_test.rb
+++ b/test/unit/resources/alicloud_ram_user_mfa_test.rb
@@ -1,10 +1,12 @@
-require "helper"
-require "alicloud_ram_user_mfa"
+# frozen_string_literal: true
+
+require 'helper'
+require 'alicloud_ram_user_mfa'
 
 class AliCloudRamUserMFAConstructorTest < Minitest::Test
   def setup
-    ENV["ALICLOUD_REGION"] = "us-east-1"
-    AliCloudRamUserMFA.any_instance.stubs(:fetch_mfa_info).returns({ "SerialNumber" => "serial", "Type" => "VMFA" })
+    ENV['ALICLOUD_REGION'] = 'us-east-1'
+    AliCloudRamUserMFA.any_instance.stubs(:fetch_mfa_info).returns({ 'SerialNumber' => 'serial', 'Type' => 'VMFA' })
   end
 
   def test_empty_params_not_ok
@@ -16,13 +18,13 @@ class AliCloudRamUserMFAConstructorTest < Minitest::Test
   end
 
   def test_accepts_string_argument
-    mfa = AliCloudRamUserMFA.new("test-user-1")
-    assert_equal "serial", mfa.serial_number
-    assert_equal "VMFA", mfa.type
+    mfa = AliCloudRamUserMFA.new('test-user-1')
+    assert_equal 'serial', mfa.serial_number
+    assert_equal 'VMFA', mfa.type
   end
 
   def test_accepts_user_name_and_region
-    mfa = AliCloudRamUserMFA.new(user_name: "test-user-1", region: "us-east-1")
-    assert_equal "VMFA", mfa.type
+    mfa = AliCloudRamUserMFA.new(user_name: 'test-user-1', region: 'us-east-1')
+    assert_equal 'VMFA', mfa.type
   end
 end

--- a/test/unit/resources/alicloud_ram_user_test.rb
+++ b/test/unit/resources/alicloud_ram_user_test.rb
@@ -1,32 +1,45 @@
-require "helper"
-require "alicloud_ram_user"
+# frozen_string_literal: true
+
+require 'helper'
+require 'alicloud_ram_user'
 
 class AliCloudRamUserConstructorTest < Minitest::Test
   def setup
-    ENV["ALICLOUD_REGION"] = "us-east-1"
+    ENV['ALICLOUD_REGION'] = 'us-east-1'
 
-    AliCloudRamUser.any_instance.stubs(:fetch_user_info).with(user_name: "test-user-1", region: "us-east-1").returns({
-      "UpdateDate" => "2021-01-01:00:00Z", "UserName" => "test-user-1", "Comments" => "A comment", "UserId" => "12345",
-      "DisplayName" => "a-test-user-1", "CreateDate" => "2021-01-01:00:00Z", "Email" => "test-user-1@some.where",
-      "MobilePhone" => "555-12345" })
-    AliCloudRamUser.any_instance.stubs(:fetch_user_info).with(user_name: "test-user-2", region: "us-east-1").returns({
-      "UpdateDate" => "2021-01-01:00:00Z", "UserName" => "test-user-2", "Comments" => "Another comment", "UserId" => "67890",
-      "DisplayName" => "a-test-user-2", "CreateDate" => "2021-01-01:00:00Z", "Email" => "test-user-2@some.where",
-      "MobilePhone" => "555-67890" })
-    AliCloudRamUser.any_instance.stubs(:fetch_user_info).with(user_name: "test-user-3", region: "us-east-1").returns({
-      "UpdateDate" => "2021-01-01:00:00Z", "UserName" => "test-user-3", "Comments" => "A third comment", "UserId" => "55555",
-      "DisplayName" => "a-test-user-", "CreateDate" => "2021-01-01:00:00Z", "Email" => "test-user-3@some.where",
-      "MobilePhone" => "555-55555" })
+    AliCloudRamUser.any_instance.stubs(:fetch_user_info).with(user_name: 'test-user-1', region: 'us-east-1').returns({
+                                                                                                                       'UpdateDate' => '2021-01-01:00:00Z', 'UserName' => 'test-user-1', 'Comments' => 'A comment', 'UserId' => '12345',
+                                                                                                                       'DisplayName' => 'a-test-user-1', 'CreateDate' => '2021-01-01:00:00Z', 'Email' => 'test-user-1@some.where',
+                                                                                                                       'MobilePhone' => '555-12345'
+                                                                                                                     })
+    AliCloudRamUser.any_instance.stubs(:fetch_user_info).with(user_name: 'test-user-2', region: 'us-east-1').returns({
+                                                                                                                       'UpdateDate' => '2021-01-01:00:00Z', 'UserName' => 'test-user-2', 'Comments' => 'Another comment', 'UserId' => '67890',
+                                                                                                                       'DisplayName' => 'a-test-user-2', 'CreateDate' => '2021-01-01:00:00Z', 'Email' => 'test-user-2@some.where',
+                                                                                                                       'MobilePhone' => '555-67890'
+                                                                                                                     })
+    AliCloudRamUser.any_instance.stubs(:fetch_user_info).with(user_name: 'test-user-3', region: 'us-east-1').returns({
+                                                                                                                       'UpdateDate' => '2021-01-01:00:00Z', 'UserName' => 'test-user-3', 'Comments' => 'A third comment', 'UserId' => '55555',
+                                                                                                                       'DisplayName' => 'a-test-user-', 'CreateDate' => '2021-01-01:00:00Z', 'Email' => 'test-user-3@some.where',
+                                                                                                                       'MobilePhone' => '555-55555'
+                                                                                                                     })
 
-    AliCloudRamUser.any_instance.stubs(:fetch_login_profile).with(user_name: "test-user-1", region: "us-east-1").returns(["UserName" => "test-user-1"])
-    AliCloudRamUser.any_instance.stubs(:fetch_login_profile).with(user_name: "test-user-2", region: "us-east-1").returns(["UserName" => "test-user-2"])
-    AliCloudRamUser.any_instance.stubs(:fetch_login_profile).with(user_name: "test-user-3", region: "us-east-1").returns(nil)
+    AliCloudRamUser.any_instance.stubs(:fetch_login_profile).with(user_name: 'test-user-1',
+                                                                  region: 'us-east-1').returns(['UserName' => 'test-user-1'])
+    AliCloudRamUser.any_instance.stubs(:fetch_login_profile).with(user_name: 'test-user-2',
+                                                                  region: 'us-east-1').returns(['UserName' => 'test-user-2'])
+    AliCloudRamUser.any_instance.stubs(:fetch_login_profile).with(user_name: 'test-user-3',
+                                                                  region: 'us-east-1').returns(nil)
 
-    AliCloudRamUser.any_instance.stubs(:fetch_access_keys).with(user_name: "test-user-1", region: "us-east-1").returns([{
-       "Status" => "Active", "AccessKeyId" => "12345" }, { "Status" => "Inactive", "AccessKeyId" => "67890" }])
-    AliCloudRamUser.any_instance.stubs(:fetch_access_keys).with(user_name: "test-user-2", region: "us-east-1").returns(nil)
-    AliCloudRamUser.any_instance.stubs(:fetch_access_keys).with(user_name: "test-user-3", region: "us-east-1").returns([{
-      "Status" => "Active", "AccessKeyId" => "55555" }])
+    AliCloudRamUser.any_instance.stubs(:fetch_access_keys).with(user_name: 'test-user-1',
+                                                                region: 'us-east-1').returns([{
+                                                                                               'Status' => 'Active', 'AccessKeyId' => '12345'
+                                                                                             }, { 'Status' => 'Inactive', 'AccessKeyId' => '67890' }])
+    AliCloudRamUser.any_instance.stubs(:fetch_access_keys).with(user_name: 'test-user-2',
+                                                                region: 'us-east-1').returns(nil)
+    AliCloudRamUser.any_instance.stubs(:fetch_access_keys).with(user_name: 'test-user-3',
+                                                                region: 'us-east-1').returns([{
+                                                                                               'Status' => 'Active', 'AccessKeyId' => '55555'
+                                                                                             }])
   end
 
   def test_empty_params_not_ok
@@ -38,30 +51,30 @@ class AliCloudRamUserConstructorTest < Minitest::Test
   end
 
   def test_accepts_string_argument
-    user = AliCloudRamUser.new("test-user-1")
-    assert_equal "test-user-1", user.user_name
-    assert_equal "12345", user.user_id
-    assert_equal "555-12345", user.mobile_phone
+    user = AliCloudRamUser.new('test-user-1')
+    assert_equal 'test-user-1', user.user_name
+    assert_equal '12345', user.user_id
+    assert_equal '555-12345', user.mobile_phone
     assert_equal true, user.has_console_access?
     assert_equal true, user.has_active_access_key?
     assert_equal true, user.has_console_and_key_access?
   end
 
   def test_accepts_key_value_argument_and_resource_works
-    user = AliCloudRamUser.new(user_name: "test-user-2")
-    assert_equal "test-user-2", user.user_name
-    assert_equal "67890", user.user_id
-    assert_equal "555-67890", user.mobile_phone
+    user = AliCloudRamUser.new(user_name: 'test-user-2')
+    assert_equal 'test-user-2', user.user_name
+    assert_equal '67890', user.user_id
+    assert_equal '555-67890', user.mobile_phone
     assert_equal true, user.has_console_access?
     assert_equal false, user.has_active_access_key?
     assert_equal false, user.has_console_and_key_access?
   end
 
   def test_accepts_user_name_and_region
-    user = AliCloudRamUser.new(user_name: "test-user-3", region: "us-east-1")
-    assert_equal "test-user-3", user.user_name
-    assert_equal "55555", user.user_id
-    assert_equal "555-55555", user.mobile_phone
+    user = AliCloudRamUser.new(user_name: 'test-user-3', region: 'us-east-1')
+    assert_equal 'test-user-3', user.user_name
+    assert_equal '55555', user.user_id
+    assert_equal '555-55555', user.mobile_phone
     assert_equal false, user.has_console_access?
     assert_equal true, user.has_active_access_key?
     assert_equal false, user.has_console_and_key_access?

--- a/test/unit/resources/alicloud_ram_users_test.rb
+++ b/test/unit/resources/alicloud_ram_users_test.rb
@@ -1,31 +1,37 @@
-require "helper"
-require "alicloud_ram_users"
+# frozen_string_literal: true
+
+require 'helper'
+require 'alicloud_ram_users'
 
 class AliCloudRamUsersConstructorTest < Minitest::Test
   def setup
-    ENV["ALICLOUD_REGION"] = "us-east-1"
+    ENV['ALICLOUD_REGION'] = 'us-east-1'
 
-    AliCloudRamUsers.any_instance.stubs(:fetch_users).returns([{ "UpdateDate" => "2021-01-01:00:00Z", "UserName" => "test-user-1",
-      "Comments" => "A comment", "UserId" => "12345", "DisplayName" => "a-test-user-1", "CreateDate" => "2021-01-01:00:00Z" },
-      { "UpdateDate" => "2021-01-01:00:00Z", "UserName" => "test-user-2", "Comments" => "Another comment", "UserId" => "67890",
-       "DisplayName" => "a-test-user-2", "CreateDate" => "2021-01-01:00:00Z" }, { "UpdateDate" => "2021-01-01:00:00Z",
-       "UserName" => "test-user-3", "Comments" => "A third comment", "UserId" => "55555", "DisplayName" => "a-test-user-2",
-       "CreateDate" => "2021-01-01:00:00Z" }])
+    AliCloudRamUsers.any_instance.stubs(:fetch_users).returns([{ 'UpdateDate' => '2021-01-01:00:00Z', 'UserName' => 'test-user-1',
+                                                                 'Comments' => 'A comment', 'UserId' => '12345', 'DisplayName' => 'a-test-user-1', 'CreateDate' => '2021-01-01:00:00Z' },
+                                                               { 'UpdateDate' => '2021-01-01:00:00Z', 'UserName' => 'test-user-2', 'Comments' => 'Another comment', 'UserId' => '67890',
+                                                                 'DisplayName' => 'a-test-user-2', 'CreateDate' => '2021-01-01:00:00Z' }, { 'UpdateDate' => '2021-01-01:00:00Z',
+                                                                                                                                            'UserName' => 'test-user-3', 'Comments' => 'A third comment', 'UserId' => '55555', 'DisplayName' => 'a-test-user-2',
+                                                                                                                                            'CreateDate' => '2021-01-01:00:00Z' }])
 
-    AliCloudRamUsers.any_instance.stubs(:fetch_login_profile).with("us-east-1", "test-user-1").returns(["UserName" => "test-user-1"])
-    AliCloudRamUsers.any_instance.stubs(:fetch_login_profile).with("us-east-1", "test-user-2").returns(["UserName" => "test-user-2"])
-    AliCloudRamUsers.any_instance.stubs(:fetch_login_profile).with("us-east-1", "test-user-3").returns(nil)
+    AliCloudRamUsers.any_instance.stubs(:fetch_login_profile).with('us-east-1',
+                                                                   'test-user-1').returns(['UserName' => 'test-user-1'])
+    AliCloudRamUsers.any_instance.stubs(:fetch_login_profile).with('us-east-1',
+                                                                   'test-user-2').returns(['UserName' => 'test-user-2'])
+    AliCloudRamUsers.any_instance.stubs(:fetch_login_profile).with('us-east-1', 'test-user-3').returns(nil)
 
-    AliCloudRamUsers.any_instance.stubs(:fetch_access_keys).with("us-east-1", "test-user-1").returns([{ "Status" => "Active",
-      "AccessKeyId" => "12345" }, { "Status" => "Inactive", "AccessKeyId" => "67890" }])
-    AliCloudRamUsers.any_instance.stubs(:fetch_access_keys).with("us-east-1", "test-user-2").returns(nil)
-    AliCloudRamUsers.any_instance.stubs(:fetch_access_keys).with("us-east-1", "test-user-3").returns([{ "Status" => "Active",
-      "AccessKeyId" => "55555" }])
+    AliCloudRamUsers.any_instance.stubs(:fetch_access_keys).with('us-east-1',
+                                                                 'test-user-1').returns([{ 'Status' => 'Active',
+                                                                                           'AccessKeyId' => '12345' }, { 'Status' => 'Inactive', 'AccessKeyId' => '67890' }])
+    AliCloudRamUsers.any_instance.stubs(:fetch_access_keys).with('us-east-1', 'test-user-2').returns(nil)
+    AliCloudRamUsers.any_instance.stubs(:fetch_access_keys).with('us-east-1',
+                                                                 'test-user-3').returns([{ 'Status' => 'Active',
+                                                                                           'AccessKeyId' => '55555' }])
 
-    AliCloudRamUsers.any_instance.stubs(:fetch_user_mfa).with("us-east-1", "test-user-1").returns({ "Type" => "VMFA",
-      "SerialNumber" => "acs:ram::1234:mfa/test-user-1" })
-    AliCloudRamUsers.any_instance.stubs(:fetch_user_mfa).with("us-east-1", "test-user-2").returns(nil)
-    AliCloudRamUsers.any_instance.stubs(:fetch_user_mfa).with("us-east-1", "test-user-3").returns(nil)
+    AliCloudRamUsers.any_instance.stubs(:fetch_user_mfa).with('us-east-1', 'test-user-1').returns({ 'Type' => 'VMFA',
+                                                                                                    'SerialNumber' => 'acs:ram::1234:mfa/test-user-1' })
+    AliCloudRamUsers.any_instance.stubs(:fetch_user_mfa).with('us-east-1', 'test-user-2').returns(nil)
+    AliCloudRamUsers.any_instance.stubs(:fetch_user_mfa).with('us-east-1', 'test-user-3').returns(nil)
   end
 
   def test_rejects_unrecognized_params
@@ -33,19 +39,19 @@ class AliCloudRamUsersConstructorTest < Minitest::Test
   end
 
   def test_rejects_string_argument
-    assert_raises(ArgumentError) { AliCloudRamUsers.new("us-west-1") }
+    assert_raises(ArgumentError) { AliCloudRamUsers.new('us-west-1') }
   end
 
   def test_accepts_no_arguments_and_resource_works
     users = AliCloudRamUsers.new
-    assert_equal %w{test-user-1 test-user-2 test-user-3}, users.user_names
-    assert_equal %w{a-test-user-1 a-test-user-2 a-test-user-2}, users.display_names
-    assert_equal %w{12345 67890 55555}, users.user_ids
+    assert_equal %w[test-user-1 test-user-2 test-user-3], users.user_names
+    assert_equal %w[a-test-user-1 a-test-user-2 a-test-user-2], users.display_names
+    assert_equal %w[12345 67890 55555], users.user_ids
     assert_equal [true, true, false], users.has_console_access
     assert_equal [true, false, true], users.has_access_key
-    assert_equal [%w{12345 67890}, [], %w{55555}], users.access_keys
+    assert_equal [%w[12345 67890], [], %w[55555]], users.access_keys
     assert_equal [true, false, true], users.has_active_access_key
-    assert_equal [%w{12345}, [], %w{55555}], users.active_access_keys
+    assert_equal [%w[12345], [], %w[55555]], users.active_access_keys
     assert_equal [true, false, false], users.has_console_and_key_access
     assert_equal [true, false, false], users.has_mfa_enabled
   end

--- a/test/unit/resources/alicloud_ram_users_test.rb
+++ b/test/unit/resources/alicloud_ram_users_test.rb
@@ -44,14 +44,14 @@ class AliCloudRamUsersConstructorTest < Minitest::Test
 
   def test_accepts_no_arguments_and_resource_works
     users = AliCloudRamUsers.new
-    assert_equal %w[test-user-1 test-user-2 test-user-3], users.user_names
-    assert_equal %w[a-test-user-1 a-test-user-2 a-test-user-2], users.display_names
-    assert_equal %w[12345 67890 55555], users.user_ids
+    assert_equal %w{test-user-1 test-user-2 test-user-3}, users.user_names
+    assert_equal %w{a-test-user-1 a-test-user-2 a-test-user-2}, users.display_names
+    assert_equal %w{12345 67890 55555}, users.user_ids
     assert_equal [true, true, false], users.has_console_access
     assert_equal [true, false, true], users.has_access_key
-    assert_equal [%w[12345 67890], [], %w[55555]], users.access_keys
+    assert_equal [%w{12345 67890}, [], %w{55555}], users.access_keys
     assert_equal [true, false, true], users.has_active_access_key
-    assert_equal [%w[12345], [], %w[55555]], users.active_access_keys
+    assert_equal [%w{12345}, [], %w{55555}], users.active_access_keys
     assert_equal [true, false, false], users.has_console_and_key_access
     assert_equal [true, false, false], users.has_mfa_enabled
   end


### PR DESCRIPTION
Signed-off-by: sa-progress <samir.anand@progress.com>

### Description

Please describe what this change achieves. Ensure you have read the [Contributing to InSpec AliCloud](https://github.com/chef-customers/inspec-alicloud/CONTRIBUTING.md) document before submitting.

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [ ] All Unit Tests pass
- [ ] `rake lint` passes
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
