### PR TITLE
added IPv6 support to security group

### DIFF
--- a/libraries/alicloud_security_group.rb
+++ b/libraries/alicloud_security_group.rb
@@ -51,20 +51,27 @@ class AliCloudSecurityGroup < AliCloudResourceBase
   end
 
   def allow_in?(criteria = {})
-    return false unless @inbound_rules.count.positive? && criteria.key?(:ipv4_range)
+    return false unless @inbound_rules.count.positive? && ( criteria.key?(:ipv4_range) || criteria.key?(:ipv6_range) )
 
     # Port is an optional parameter so we can write controls against CIDR masks only
     port = criteria[:port] unless criteria[:port].nil?
-    ipv4_range = criteria[:ipv4_range]
+    ipv4_range = criteria[:ipv4_range] unless criteria[:ipv4_range].nil?
+    ipv6_range = criteria[:ipv6_range] unless criteria[:ipv6_range].nil?
+
     @inbound_rules.each do |rule|
-      # If our rule has a securitygroup ID instead of a CIDR mask as the auth object, skip it...
-      next if rule['SourceCidrIp'].empty? && !rule['SourceGroupId'].empty?
+      # If our rule has a securitygroup ID or IP address familiy does not match the one in criteria, skip it...
+      next if !rule['SourceGroupId'].empty? || ( criteria.key?(:ipv4_range) && rule['SourceCidrIp'].empty? ) \
+      || ( criteria.key?(:ipv6_range) && rule['Ipv6SourceCidrIp'].empty? )
 
       policy = rule['Policy']
       next unless policy == 'Accept'
 
-      cidr = IPAddr.new(rule['SourceCidrIp'])
-      next unless cidr.include?(IPAddr.new(ipv4_range))
+      cidr = IPAddr.new(rule['SourceCidrIp'], Socket::AF_INET) unless rule['SourceCidrIp'].empty?
+      cidr_6 = IPAddr.new(rule['Ipv6SourceCidrIp'], Socket::AF_INET6) unless rule['Ipv6SourceCidrIp'].empty?
+
+      # If the authorized source address does not include IP range in the criteria, skip it...
+      next if ( !rule['SourceCidrIp'].empty? && !cidr.include?(IPAddr.new(ipv4_range, Socket::AF_INET)) ) || \
+        ( !rule['Ipv6SourceCidrIp'].empty? && !cidr_6.include?(IPAddr.new(ipv6_range, Socket::AF_INET6)) )
 
       # This block is conditional on 'port' having been passed in, otherwise we only care about the previous two checks
       if port.nil?


### PR DESCRIPTION
Signed-off-by: Jiaming Wang <jiaming.wang@sap.com>

### Description

Current `alicloud_security_group.rb` does not support IPv6 checks for method `allow_in?`. When scanning an inbound rule w/ IPv6 source address (does not authorize source as IPv4 addresses nor security groups), it will lead to output message `invalid address: `
Updated `allow_in?` method to support inbound rule checks for IPv6 source addresses by using criteria parameter named `ipv6_range`

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [x] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [ ] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
