### PR TITLE
fixed error from oss bucket resource id

### DIFF
--- a/libraries/alicloud_oss_bucket.rb
+++ b/libraries/alicloud_oss_bucket.rb
@@ -88,7 +88,7 @@ class AliCloudOssBucket < AliCloudResourceBase
   end
 
   def resource_id
-    @bucket ? @bucket[:bucket_name] : @bucket_name
+    @bucket ? @bucket.name : @bucket_name
   end
 
   def to_s


### PR DESCRIPTION
Signed-off-by: Jiaming Wang <jiaming.wang@sap.com>

### Description

The `resource_id` method in alicloud_oss_bucket.rb will always return an error due to the structure of `@bucket`. Fixed the error using `@bucket.name` instead of `@bucket[:bucket_name]` at line 91.

### Issues Resolved

Current issue when calling resource_id method:
`NoMethodError: undefined method '[]' for #<Aliyun::OSS::Bucket`

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [ ] All Unit Tests pass
- [ ] `rake lint` passes
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
