### PR TITLE
RESOURCE-526 Add the missing Integration test in inspec-alicloud

### DIFF
--- a/test/integration/verify/controls/alicloud_ims_sso.rb
+++ b/test/integration/verify/controls/alicloud_ims_sso.rb
@@ -3,7 +3,7 @@ title 'Test AliCloud IMS SSO Properties'
 control 'alicloud_ims_sso-1.0' do
   impact 1.0
   title 'Ensure AliCloud IMS SSO has correct attributes.'
-  
+
   describe alicloud_ims_sso do
     it { should exist }
     it { have_sso_enabled }

--- a/test/integration/verify/controls/alicloud_ims_sso.rb
+++ b/test/integration/verify/controls/alicloud_ims_sso.rb
@@ -1,0 +1,12 @@
+title 'Test AliCloud IMS SSO Properties'
+
+control 'alicloud_ims_sso-1.0' do
+  impact 1.0
+  title 'Ensure AliCloud IMS SSO has correct attributes.'
+  
+  describe alicloud_ims_sso do
+    it { should exist }
+    it { have_sso_enabled }
+    its('idp_domain') { should cmp 'mydomain.com' }
+  end
+end

--- a/test/integration/verify/controls/alicloud_resource_directory.rb
+++ b/test/integration/verify/controls/alicloud_resource_directory.rb
@@ -5,8 +5,8 @@ control 'alicloud_resource_directory-1.0' do
   title 'Ensure AliCloud Resource Directory has the correct properties.'
 
   describe alicloud_resource_directory do
-    it { should exist}
-    its( 'resource_directory_id' ) {should_not eq 'rd_id'}
-    its( 'master_account_name' ) {should_not eq 'master_acct_name'}
+    it { should exist }
+    its( 'resource_directory_id' ) { should_not eq 'rd_id' }
+    its( 'master_account_name' ) { should_not eq 'master_acct_name' }
   end
 end

--- a/test/integration/verify/controls/alicloud_resource_directory.rb
+++ b/test/integration/verify/controls/alicloud_resource_directory.rb
@@ -1,0 +1,12 @@
+title 'Test single AliCloud Resource Directory'
+
+control 'alicloud_resource_directory-1.0' do
+  impact 1.0
+  title 'Ensure AliCloud Resource Directory has the correct properties.'
+
+  describe alicloud_resource_directory do
+    it { should exist}
+    its( 'resource_directory_id' ) {should_not eq 'rd_id'}
+    its( 'master_account_name' ) {should_not eq 'master_acct_name'}
+  end
+end

--- a/test/integration/verify/controls/alicloud_slb_https_listener.rb
+++ b/test/integration/verify/controls/alicloud_slb_https_listener.rb
@@ -1,0 +1,18 @@
+alicloud_slb_https_id = input(:alicloud_slb_https_id, value: '', description: 'AliCloud slb https ID.')
+
+title 'Test single AliCloud Server Load Balance HTTPS Listener'
+
+control 'alicloud_slb_https_listener-1.0' do
+  impact 1.0
+  title 'Ensure AliCloud Server Load Balancer has the correct properties.'
+
+  describe alicloud_slb_https_listener(slb_id: alicloud_slb_https_id, listener_port: 443) do
+    it { should exist }
+  end
+  
+  alicloud_slb(alicloud_slb_https_id).https_ports.each do |port|
+    describe alicloud_slb_https_listener(slb_id: alicloud_slb_https_id, listener_port: port) do
+      its('tls_cipher_policy') { should eq 'tls_cipher_policy_1_2' }
+    end
+  end
+end

--- a/test/integration/verify/controls/alicloud_slb_https_listener.rb
+++ b/test/integration/verify/controls/alicloud_slb_https_listener.rb
@@ -9,7 +9,7 @@ control 'alicloud_slb_https_listener-1.0' do
   describe alicloud_slb_https_listener(slb_id: alicloud_slb_https_id, listener_port: 443) do
     it { should exist }
   end
-  
+
   alicloud_slb(alicloud_slb_https_id).https_ports.each do |port|
     describe alicloud_slb_https_listener(slb_id: alicloud_slb_https_id, listener_port: port) do
       its('tls_cipher_policy') { should eq 'tls_cipher_policy_1_2' }


### PR DESCRIPTION
Signed-off-by: Soumyodeep Karmakar <soumyo.k13@gmail.com>

### Description

These 3 Integration tests are missing. Please add the below missing integration test:

1. alicloud_ims_sso
2. alicloud_slb_https_listener
3. alicloud_resource_directory

### Issues Resolved

These 3 Integration tests are missing.

### Check List
Please fill a box or appropriate ([x]) or mark N/A.
- [x] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [x] Documentation provided or updated for resources 
- [x] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
