### PR TITLE
RESOURCE-542 Remove frozen string literal from inspec alicloud

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 source "https://rubygems.org"
 
 gem "bundle"

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,4 @@
 #!/usr/bin/env rake
-# frozen_string_literal: true
 
 require "rake/testtask"
 require "chefstyle"
@@ -9,10 +8,10 @@ require_relative "test/integration/configuration/alicloud_inspec_config"
 INTEGRATION_DIR = File.join("test", "integration")
 CONTROLS_DIR = File.join(INTEGRATION_DIR, "verify")
 TERRAFORM_DIR = File.join(INTEGRATION_DIR, "build")
-TF_VAR_FILE_NAME = "inspec-alicloud.tfvars.json"
+TF_VAR_FILE_NAME = "inspec-alicloud.tfvars.json".freeze
 TF_VAR_FILE = File.join(TERRAFORM_DIR, TF_VAR_FILE_NAME)
-TF_PLAN_FILE = "inspec-alicloud.plan"
-PROFILE_ATTRIBUTES = "alicloud-inspec-attributes.yaml"
+TF_PLAN_FILE = "inspec-alicloud.plan".freeze
+PROFILE_ATTRIBUTES = "alicloud-inspec-attributes.yaml".freeze
 
 # Rubocop
 desc "Run Rubocop lint checks"
@@ -31,8 +30,8 @@ Rake::TestTask.new do |t|
 end
 
 # run tests
-#  Disabling inspec check on profile with path dependency due to https://github.com/inspec/inspec/issues/3571 - 'test:check'
-desc "Run robocop linter + unit tests"
+# Disabling inspec check on profile with path dependency due to https://github.com/inspec/inspec/issues/3571 - 'test:check'
+desc "Run rubocop linter + unit tests"
 task default: [:lint, :test]
 
 namespace :test do
@@ -110,12 +109,12 @@ namespace :tf do
 end
 
 namespace :docs do
-  desc "Prints markdown links for resource doc files to update the README"
+  desc "Prints markdown links for resource doc files to update the README."
   task :resource_links do
     puts "\n"
     # Until we have documentation, just generate list from the resources directly
     # Dir.entries('docs/resources').sort
-    #  .collect { |file| "- [#{file.split('.')[0]}](docs/resources/#{file})" }
+    # .collect { |file| "- [#{file.split('.')[0]}](docs/resources/#{file})" }
 
     Dir.entries("libraries").sort
       .reject { |file| File.directory?(file) }

--- a/libraries/alicloud_vpc.rb
+++ b/libraries/alicloud_vpc.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require 'alicloud_backend'
 
 class AliCloudVpc < AliCloudResourceBase

--- a/libraries/alicloud_vpcs.rb
+++ b/libraries/alicloud_vpcs.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require 'alicloud_backend'
 
 class AliCloudVpcs < AliCloudResourceBase

--- a/test/integration/configuration/alicloud_inspec_config.rb
+++ b/test/integration/configuration/alicloud_inspec_config.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # Configuration helper for AliCloud & Inspec
 # - Terraform expects a JSON variable file
 # - Inspec expects a YAML attribute file

--- a/test/integration/verify/controls/alicloud_actiontrail_trail.rb
+++ b/test/integration/verify/controls/alicloud_actiontrail_trail.rb
@@ -1,14 +1,11 @@
-# frozen_string_literal: true
-
 title 'Test single AliCloud ActionTrail'
 
 alicloud_action_trail_name = input(:alicloud_action_trail_name, value: '', description: 'Action trail name')
-alicloud_action_trail_bucket_id = input(:alicloud_action_trail_bucket_id, value: '',
-                                                                          description: 'Action trail bucket name')
+alicloud_action_trail_bucket_id = input(:alicloud_action_trail_bucket_id, value: '', description: 'Action trail bucket name')
 
 control 'alicloud-actiontrail-1.0' do
   impact 1.0
-  title 'Ensure AliCloud Action Trail has the correct properties.'
+  title 'Ensure AliCloud ActionTrail has the correct properties.'
 
   describe alicloud_actiontrail_trail(alicloud_action_trail_name) do
     it { should exist }

--- a/test/integration/verify/controls/alicloud_actiontrail_trails.rb
+++ b/test/integration/verify/controls/alicloud_actiontrail_trails.rb
@@ -1,12 +1,10 @@
-# frozen_string_literal: true
-
 title 'Test AliCloud ActionTrails in bulk'
 
 alicloud_action_trail_name = input(:alicloud_action_trail_name, value: '', description: 'Action trail name')
 
 control 'alicloud-actiontrails-1.0' do
   impact 1.0
-  title 'Ensure AlicCloud Action Trail plural resource has the correct properties.'
+  title 'Ensure AliCloud ActionTrail plural resource has the correct properties.'
 
   describe alicloud_actiontrail_trails do
     it { should exist }

--- a/test/integration/verify/controls/alicloud_apsaradb_rds_instance.rb
+++ b/test/integration/verify/controls/alicloud_apsaradb_rds_instance.rb
@@ -1,20 +1,16 @@
-# frozen_string_literal: true
+alicloud_rds_db_id = input(:alicloud_rds_db_id, value: '', description: 'The AliCloud RDS DB identifier.')
+alicloud_rds_db_name = input(:alicloud_rds_db_name, value: '', description: 'The AliCloud RDS DB name.')
+alicloud_rds_db_engine = input(:alicloud_rds_db_engine, value: '', description: 'The AliCloud RDS DB engine.')
+alicloud_rds_db_engine_version = input(:alicloud_rds_db_engine_version, value: '', description: 'The AliCloud RDS DB engine version.')
+alicloud_rds_storage = input(:alicloud_rds_storage, value: '', description: 'The AliCloud RDS allocated storage.')
+alicloud_rds_instance_type = input(:alicloud_rds_instance_type, value: '', description: 'The AliCloud RDS instance type.')
+alicloud_rds_vpc_id = input(:alicloud_vpc_id, value: '', description: 'The AliCloud VPC ID for the DB.')
+alicloud_rds_security_ips = input(:alicloud_vpc_cidr, value: '', description: 'The AliCloud RDS security IPs.')
 
-alicloud_rds_db_id = attribute(:alicloud_rds_db_id, value: '', description: 'The Alicloud RDS DB identifier.')
-alicloud_rds_db_name = attribute(:alicloud_rds_db_name, value: '', description: 'The Alicloud RDS DB name.')
-alicloud_rds_db_engine = attribute(:alicloud_rds_db_engine, value: '', description: 'The Alicloud RDS DB engine.')
-alicloud_rds_db_engine_version = attribute(:alicloud_rds_db_engine_version, value: '',
-                                                                            description: 'The Alicloud RDS DB engine version.')
-alicloud_rds_storage = attribute(:alicloud_rds_storage, value: '', description: 'The Alicloud RDS allocated storage.')
-alicloud_rds_instance_type = attribute(:alicloud_rds_instance_type, value: '',
-                                                                    description: 'The Alicloud RDS instance type.')
-alicloud_rds_vpc_id = attribute(:alicloud_vpc_id, value: '', description: 'The Alicloud VPC ID for the DB.')
-alicloud_rds_security_ips = attribute(:alicloud_vpc_cidr, value: '', description: 'The Alicloud RDS security IPs.')
-
-title 'Test single Alicloud ApsaraDB RDS Instance'
+title 'Test single AliCloud ApsaraDB RDS Instance'
 control 'alicloud-apsaradb-rds-instance-1.0' do
   impact 1.0
-  title 'Ensure Alicloud ApsaraDB RDS Instance has the correct properties.'
+  title 'Ensure AliCloud ApsaraDB RDS Instance has the correct properties.'
 
   describe alicloud_apsaradb_rds_instance(db_instance_id: alicloud_rds_db_id) do
     it { should exist }

--- a/test/integration/verify/controls/alicloud_apsaradb_rds_instances.rb
+++ b/test/integration/verify/controls/alicloud_apsaradb_rds_instances.rb
@@ -1,11 +1,10 @@
-# frozen_string_literal: true
+alicloud_rds_db_id = input(:alicloud_rds_db_id, value: '', description: 'The Alicloud RDS DB identifier.')
 
-alicloud_rds_db_id = attribute(:alicloud_rds_db_id, value: '', description: 'The Alicloud RDS DB identifier.')
+title 'Test multiple AliCloud ApsaraDB RDS Instances'
 
-title 'Test multiple Alicloud ApsaraDB RDS Instances'
 control 'alicloud-apsaradb-rds-instances-1.0' do
   impact 1.0
-  title 'Ensure Alicloud ApsaraDB RDS Instances have the correct properties.'
+  title 'Ensure AliCloud ApsaraDB RDS Instances have the correct properties.'
 
   describe alicloud_apsaradb_rds_instances do
     it { should exist }

--- a/test/integration/verify/controls/alicloud_disk.rb
+++ b/test/integration/verify/controls/alicloud_disk.rb
@@ -1,18 +1,12 @@
-# frozen_string_literal: true
-
-alicloud_disk_id        = input(:alicloud_disk_id, value: '', description: 'AliCloud Disk ID.')
-alicloud_disk_name      = input(:alicloud_disk_name, value: '', description: 'AliCloud Disk Name.')
-alicloud_disk_desc      = input(:alicloud_disk_desc, value: '', description: 'AliCloud Disk Desc.')
-alicloud_disk_size      = input(:alicloud_disk_size, value: '', description: 'AliCloud Disk Size.')
-alicloud_disk_category  = input(:alicloud_disk_category, value: '', description: 'AliCloud Disk Category.')
+alicloud_disk_id = input(:alicloud_disk_id, value: '', description: 'AliCloud Disk ID.')
+alicloud_disk_name = input(:alicloud_disk_name, value: '', description: 'AliCloud Disk Name.')
+alicloud_disk_desc = input(:alicloud_disk_desc, value: '', description: 'AliCloud Disk Desc.')
+alicloud_disk_size = input(:alicloud_disk_size, value: '', description: 'AliCloud Disk Size.')
+alicloud_disk_category = input(:alicloud_disk_category, value: '', description: 'AliCloud Disk Category.')
 alicloud_disk_encrypted = input(:alicloud_disk_encrypted, value: '', description: 'AliCloud Disk Encrypted.')
-alicloud_disk_delete_with_instance = input(:alicloud_disk_delete_with_instance, value: '',
-                                                                                description: 'AliCloud Disk DeleteWithInstance.')
-alicloud_disk_enable_auto_snapshot = input(:alicloud_disk_enable_auto_snapshot, value: '',
-                                                                                description: 'AliCloud Disk EnableAutoSnapshot.')
-alicloud_disk_delete_auto_snapshot = input(:alicloud_disk_delete_auto_snapshot, value: '',
-                                                                                description: 'AliCloud Disk DeleteAutoSnapshot.')
-# alicloud_disk_tags      = input(:alicloud_disk_tags, value: "", description: "AliCloud Disk Tags.")
+alicloud_disk_delete_with_instance = input(:alicloud_disk_delete_with_instance, value: '', description: 'AliCloud Disk DeleteWithInstance.')
+alicloud_disk_enable_auto_snapshot = input(:alicloud_disk_enable_auto_snapshot, value: '', description: 'AliCloud Disk EnableAutoSnapshot.')
+alicloud_disk_delete_auto_snapshot = input(:alicloud_disk_delete_auto_snapshot, value: '', description: 'AliCloud Disk DeleteAutoSnapshot.')
 
 title 'Test single AliCloud Disk'
 

--- a/test/integration/verify/controls/alicloud_disks.rb
+++ b/test/integration/verify/controls/alicloud_disks.rb
@@ -1,12 +1,10 @@
-# frozen_string_literal: true
-
 title 'Test AliCloud Disk in bulk'
 
 control 'alicloud-disks-1.0' do
   impact 1.0
   title 'Ensure AliCloud disk plural resource has the correct properties.'
 
-  # Verify that you have disks defiend
+  # Verify that you have disks defined
   describe alicloud_disks do
     it { should exist }
   end

--- a/test/integration/verify/controls/alicloud_ecs_instance.rb
+++ b/test/integration/verify/controls/alicloud_ecs_instance.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 alicloud_instance_id = input(:alicloud_instance_id, value: '', description: 'AliCloud test instance ID.')
 alicloud_ram_role_name = input(:alicloud_ram_role_name, value: '', description: 'AliCloud RAM role name.')
 
@@ -7,7 +5,7 @@ title 'Test single AliCloud ECS Instance'
 
 control 'alicloud-instance-1.0' do
   impact 1.0
-  title 'Ensure Alicloud ECS Instance Class has correct attributes'
+  title 'Ensure AliCloud ECS Instance Class has correct attributes'
 
   describe alicloud_ecs_instance(instance_id: alicloud_instance_id) do # gets region from env var
     it { should exist }

--- a/test/integration/verify/controls/alicloud_ecs_instances.rb
+++ b/test/integration/verify/controls/alicloud_ecs_instances.rb
@@ -1,12 +1,10 @@
-# frozen_string_literal: true
-
 alicloud_instance_id = input(:alicloud_instance_id, value: '', description: 'AliCloud test instance ID.')
 
 title 'Test AliCloud ECS Group resource'
 
 control 'alicloud-instances-1.0' do
   impact 1.0
-  title 'Ensure Alicloud ECS Instances Class has correct attributes'
+  title 'Ensure AliCloud ECS Instances Class has correct attributes'
 
   describe alicloud_ecs_instances do  # gets region from env var
     it { should exist }

--- a/test/integration/verify/controls/alicloud_oss_bucket.rb
+++ b/test/integration/verify/controls/alicloud_oss_bucket.rb
@@ -1,18 +1,14 @@
-# frozen_string_literal: true
-
 title 'Test single AliCloud OSS Bucket'
 
-alicloud_action_trail_bucket_id = input(:alicloud_action_trail_bucket_id, value: '',
-                                                                          description: 'Action trail bucket name')
-alicloud_bucket_acl_name = input(:alicloud_bucket_acl_name, value: '', description: 'OSS bucket name')
-alicloud_bucket_encrypted_name = input(:alicloud_bucket_encrypted_name, value: '', description: 'OSS bucket name')
-alicloud_bucket_lifecycle_name = input(:alicloud_bucket_lifecycle_name, value: '', description: 'OSS bucket name')
-alicloud_bucket_logging_name = input(:alicloud_bucket_logging_name, value: '', description: 'OSS bucket name')
-alicloud_bucket_logging_target_name = input(:alicloud_bucket_logging_target_name, value: '',
-                                                                                  description: 'OSS bucket name')
-alicloud_bucket_tags_name = input(:alicloud_bucket_tags_name, value: '', description: 'OSS bucket name')
-alicloud_bucket_versioning_name = input(:alicloud_bucket_versioning_name, value: '', description: 'OSS bucket name')
-alicloud_bucket_website_name = input(:alicloud_bucket_website_name, value: '', description: 'OSS bucket name')
+alicloud_action_trail_bucket_id = input(:alicloud_action_trail_bucket_id, value: '', description: '')
+alicloud_bucket_acl_name = input(:alicloud_bucket_acl_name, value: '', description: '')
+alicloud_bucket_encrypted_name = input(:alicloud_bucket_encrypted_name, value: '', description: '')
+alicloud_bucket_lifecycle_name = input(:alicloud_bucket_lifecycle_name, value: '', description: '')
+alicloud_bucket_logging_name = input(:alicloud_bucket_logging_name, value: '', description: '')
+alicloud_bucket_logging_target_name = input(:alicloud_bucket_logging_target_name, value: '', description: '')
+alicloud_bucket_tags_name = input(:alicloud_bucket_tags_name, value: '', description: '')
+alicloud_bucket_versioning_name = input(:alicloud_bucket_versioning_name, value: '', description: '')
+alicloud_bucket_website_name = input(:alicloud_bucket_website_name, value: '', description: '')
 
 control 'alicloud-ossbucket-1.0' do
   impact 1.0

--- a/test/integration/verify/controls/alicloud_oss_buckets.rb
+++ b/test/integration/verify/controls/alicloud_oss_buckets.rb
@@ -1,18 +1,14 @@
-# frozen_string_literal: true
-
 title 'Test AliCloud OSS Buckets in bulk'
 
-alicloud_action_trail_bucket_id = input(:alicloud_action_trail_bucket_id, value: '',
-                                                                          description: 'Action trail bucket name')
-alicloud_bucket_acl_name = input(:alicloud_bucket_acl_name, value: '', description: 'OSS bucket name')
-alicloud_bucket_encrypted_name = input(:alicloud_bucket_encrypted_name, value: '', description: 'OSS bucket name')
-alicloud_bucket_lifecycle_name = input(:alicloud_bucket_lifecycle_name, value: '', description: 'OSS bucket name')
-alicloud_bucket_logging_name = input(:alicloud_bucket_logging_name, value: '', description: 'OSS bucket name')
-alicloud_bucket_logging_target_name = input(:alicloud_bucket_logging_target_name, value: '',
-                                                                                  description: 'OSS bucket name')
-alicloud_bucket_tags_name = input(:alicloud_bucket_tags_name, value: '', description: 'OSS bucket name')
-alicloud_bucket_versioning_name = input(:alicloud_bucket_versioning_name, value: '', description: 'OSS bucket name')
-alicloud_bucket_website_name = input(:alicloud_bucket_website_name, value: '', description: 'OSS bucket name')
+alicloud_action_trail_bucket_id = input(:alicloud_action_trail_bucket_id, value: '', description: '')
+alicloud_bucket_acl_name = input(:alicloud_bucket_acl_name, value: '', description: '')
+alicloud_bucket_encrypted_name = input(:alicloud_bucket_encrypted_name, value: '', description: '')
+alicloud_bucket_lifecycle_name = input(:alicloud_bucket_lifecycle_name, value: '', description: '')
+alicloud_bucket_logging_name = input(:alicloud_bucket_logging_name, value: '', description: '')
+alicloud_bucket_logging_target_name = input(:alicloud_bucket_logging_target_name, value: '', description: '')
+alicloud_bucket_tags_name = input(:alicloud_bucket_tags_name, value: '', description: '')
+alicloud_bucket_versioning_name = input(:alicloud_bucket_versioning_name, value: '', description: '')
+alicloud_bucket_website_name = input(:alicloud_bucket_website_name, value: '', description: '')
 
 control 'alicloud-oss-buckets-1.0' do
   impact 1.0

--- a/test/integration/verify/controls/alicloud_ram_access_key.rb
+++ b/test/integration/verify/controls/alicloud_ram_access_key.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 alicloud_ram_user_name = input(:alicloud_ram_user_name, value: '', description: "AliCloud RAM User's name.")
 alicloud_ram_access_key_id = input(:alicloud_ram_access_key_id, value: '', description: 'AliCloud Access Key ID')
 
@@ -7,7 +5,7 @@ title 'Test AliCloud access key'
 
 control 'alicloud-access-key-1.0' do
   impact 1.0
-  title 'Ensure Alicloud access key library has correct properties'
+  title 'Ensure AliCloud access key library has correct properties'
 
   describe alicloud_access_key(ENV['ALICLOUD_ACCESS_KEY']) do
     its('access_key_id') { should eq ENV['ALICLOUD_ACCESS_KEY'] }

--- a/test/integration/verify/controls/alicloud_ram_access_keys.rb
+++ b/test/integration/verify/controls/alicloud_ram_access_keys.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 alicloud_ram_user_name = input(:alicloud_ram_user_name, value: '', description: "AliCloud RAM User's name.")
 alicloud_ram_access_key_id = input(:alicloud_ram_access_key_id, value: '', description: 'AliCloud Access Key ID')
 
@@ -7,7 +5,7 @@ title 'Test AliCloud access keys group'
 
 control 'alicloud-access-keys-1.0' do
   impact 1.0
-  title 'Ensure Alicloud access key library has correct properties'
+  title 'Ensure AliCloud access key library has correct properties'
 
   describe alicloud_access_keys do
     it { should exist }

--- a/test/integration/verify/controls/alicloud_ram_password_policy.rb
+++ b/test/integration/verify/controls/alicloud_ram_password_policy.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 title 'Test Alicloud RAM Password Policy'
 
 control 'alicloud-ram-1.0' do

--- a/test/integration/verify/controls/alicloud_ram_policies.rb
+++ b/test/integration/verify/controls/alicloud_ram_policies.rb
@@ -1,14 +1,11 @@
-# frozen_string_literal: true
-
 title 'Test a collection of AliCloud RAM Policies'
 
-alicloud_ram_policy_name = attribute(:alicloud_ram_policy_name, value: '', description: 'The Alicloud RAM Policy name.')
-alicloud_ram_attached_policy_name_1 = attribute(:alicloud_ram_attached_policy_name_1, value: '',
-                                                                                      description: 'The Alicloud RAM Attached Policy 1 name.')
+alicloud_ram_policy_name = attribute(:alicloud_ram_policy_name, value: '', description: 'The AliCloud RAM Policy name.')
+alicloud_ram_attached_policy_name_1 = attribute(:alicloud_ram_attached_policy_name_1, value: '', description: 'The AliCloud RAM Attached Policy 1 name.')
 
 control 'alicloud-ram-policies-1.0' do
   impact 1.0
-  title 'Ensure AliCLoud RAM Policies have the correct properties.'
+  title 'Ensure AliCloud RAM Policies have the correct properties.'
 
   describe alicloud_ram_policies do
     it { should exist }

--- a/test/integration/verify/controls/alicloud_ram_policy.rb
+++ b/test/integration/verify/controls/alicloud_ram_policy.rb
@@ -1,19 +1,15 @@
-# frozen_string_literal: true
+title 'Test single AliCloud RAM Policy'
 
-title 'Test single Alicloud RAM Policy'
-
-alicloud_ram_policy_name = attribute(:alicloud_ram_policy_name, value: '', description: 'The Alicloud RAM Policy name.')
-alicloud_ram_attached_policy_name_1 = attribute(:alicloud_ram_attached_policy_name_1, value: '',
-                                                                                      description: 'The Attached Alicloud RAM Policy 1 name.')
-alicloud_ram_attached_policy_name_2 = attribute(:alicloud_ram_attached_policy_name_2, value: '',
-                                                                                      description: 'The Attached Alicloud RAM Policy 2 name.')
-alicloud_ram_user_name = attribute(:alicloud_ram_user_name, value: '', description: 'The Alicloud RAM User name.')
-alicloud_ram_group_name = attribute(:alicloud_ram_group_name, value: '', description: 'The Alicloud RAM Group name.')
-alicloud_ram_role_arn = attribute(:alicloud_ram_role_arn, value: '', description: 'The Alicloud RAM Role ARN.')
+alicloud_ram_policy_name = input(:alicloud_ram_policy_name, value: '', description: 'The AliCloud RAM Policy name.')
+alicloud_ram_attached_policy_name_1 = input(:alicloud_ram_attached_policy_name_1, value: '', description: 'The Attached AliCloud RAM Policy 1 name.')
+alicloud_ram_attached_policy_name_2 = input(:alicloud_ram_attached_policy_name_2, value: '', description: 'The Attached AliCloud RAM Policy 2 name.')
+alicloud_ram_user_name = input(:alicloud_ram_user_name, value: '', description: 'The AliCloud RAM User name.')
+alicloud_ram_group_name = input(:alicloud_ram_group_name, value: '', description: 'The AliCloud RAM Group name.')
+alicloud_ram_role_arn = input(:alicloud_ram_role_arn, value: '', description: 'The AliCloud RAM Role ARN.')
 
 control 'alicloud-ram-policy-1.0' do
   impact 1.0
-  title 'Ensure Alicloud RAM Policy has the correct properties.'
+  title 'Ensure AliCloud RAM Policy has the correct properties.'
 
   describe alicloud_ram_policy(policy_name: 'DoesNotExist') do
     it { should_not exist }

--- a/test/integration/verify/controls/alicloud_ram_user.rb
+++ b/test/integration/verify/controls/alicloud_ram_user.rb
@@ -1,21 +1,14 @@
-# frozen_string_literal: true
+alicloud_ram_user_name = input(:alicloud_ram_user_name, value: '', description: "AliCloud RAM User's name.")
+alicloud_ram_user_display_name = input(:alicloud_ram_user_display_name, value: '', description: "AliCloud RAM User's display name.")
+alicloud_ram_user_mobile = input(:alicloud_ram_user_mobile, value: '', description: "AliCloud RAM User's mobile.")
+alicloud_ram_user_email = input(:alicloud_ram_user_email, value: '', description: "AliCloud RAM User's Email.")
+alicloud_ram_user_name_2 = input(:alicloud_ram_user_name_2, value: '', description: "AliCloud RAM Second User's name.")
 
-alicloud_ram_user_name = input(:alicloud_ram_user_name, value: '',
-                                                        description: "AliCloud RAM User's name.")
-alicloud_ram_user_display_name = input(:alicloud_ram_user_display_name, value: '',
-                                                                        description: "AliCloud RAM User's display name.")
-alicloud_ram_user_mobile = input(:alicloud_ram_user_mobile, value: '',
-                                                            description: "AliCloud RAM User's mobile.")
-alicloud_ram_user_email = input(:alicloud_ram_user_email, value: '',
-                                                          description: "AliCloud RAM User's Email.")
-alicloud_ram_user_name_2 = input(:alicloud_ram_user_name_2, value: '',
-                                                            description: "AliCloud RAM Second User's name.")
-
-title 'Test single Alicloud RAM user'
+title 'Test single AliCloud RAM user'
 
 control 'alicloud-ram-user-1.0' do
   impact 1.0
-  title 'Ensure RAM user library has correct properties'
+  title 'Ensure AliCloud RAM user library has correct properties'
 
   describe alicloud_ram_user(alicloud_ram_user_name) do
     it { should exist }

--- a/test/integration/verify/controls/alicloud_ram_user_mfa.rb
+++ b/test/integration/verify/controls/alicloud_ram_user_mfa.rb
@@ -1,14 +1,12 @@
-# frozen_string_literal: true
-
 # no terraform module for mfa yet https://www.terraform.io/docs/providers/alicloud/index.html
 # alicloud_ram_user_name = input(:alicloud_ram_user_name, value: "", description: "AliCloud RAM User's name.")
 # alicloud_ram_user_mfa_serial_number   = input(:alicloud_ram_user_mfa_serial_number, value: '', description: 'AliCloud RAM User\'s mfa serial number.')
 
-title 'Test Alicloud RAM User MFA'
+title 'Test AliCloud RAM User MFA'
 
 control 'alicloud-ram-user-mfa-1.0' do
   impact 1.0
-  title 'Ensure RAM user MFA library has correct properties'
+  title 'Ensure AliCloud RAM user MFA library has correct properties'
 
   # describe alicloud_ram_user_mfa(alicloud_ram_user_name) do
   #   it { should exist }

--- a/test/integration/verify/controls/alicloud_ram_users.rb
+++ b/test/integration/verify/controls/alicloud_ram_users.rb
@@ -1,13 +1,11 @@
-# frozen_string_literal: true
-
 alicloud_ram_user_name = input(:alicloud_ram_user_name, value: '', description: "AliCloud RAM User's name.")
 alicloud_ram_user_name_2 = input(:alicloud_ram_user_name_2, value: '', description: "AliCloud second RAM User's name.")
 
-title 'Test Alicloud RAM plural users'
+title 'Test AliCloud RAM plural users'
 
-control 'alicloud-ram-users-1.0' do
+control 'AliCloud-ram-users-1.0' do
   impact 1.0
-  title 'Ensure RAM user list library has correct properties'
+  title 'Ensure AliCloud RAM user list library has correct properties'
 
   describe alicloud_ram_users do
     its('entries.count') { should be > 1 }

--- a/test/integration/verify/controls/alicloud_region.rb
+++ b/test/integration/verify/controls/alicloud_region.rb
@@ -1,10 +1,7 @@
-# frozen_string_literal: true
-
 title 'Test single AliCloud region'
 
-alicloud_region_exists = input(:alicloud_region_exists, value: 'eu-west-1', description: 'An AliCloud region.')
-alicloud_region_endpoint_exists = input(:alicloud_region_endpoint_exists, value: 'ecs.eu-west-1.aliyuncs.com',
-                                                                          description: 'An AliCloud region.')
+alicloud_region_exists = input(:alicloud_region_exists, value: '', description: 'An AliCloud region.')
+alicloud_region_endpoint_exists = input(:alicloud_region_endpoint_exists, value: '', description: 'An AliCloud region endpoint.')
 
 control 'alicloud-region-1.0' do
   impact 1.0

--- a/test/integration/verify/controls/alicloud_regions.rb
+++ b/test/integration/verify/controls/alicloud_regions.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 title 'Test AliCloud Regions in bulk'
 
 control 'alicloud-regions-1.0' do

--- a/test/integration/verify/controls/alicloud_resource_directory.rb
+++ b/test/integration/verify/controls/alicloud_resource_directory.rb
@@ -1,6 +1,6 @@
 title 'Test single AliCloud Resource Directory'
 
-control 'alicloud_resource_directory-1.0' do
+skip_control 'alicloud_resource_directory-1.0' do
   impact 1.0
   title 'Ensure AliCloud Resource Directory has the correct properties.'
 

--- a/test/integration/verify/controls/alicloud_security_group.rb
+++ b/test/integration/verify/controls/alicloud_security_group.rb
@@ -1,20 +1,11 @@
-# frozen_string_literal: true
-
 alicloud_vpc_id = input(:alicloud_vpc_id, value: '', description: 'AliCloud VPC ID.')
-alicloud_security_group_alpha_id = input(:alicloud_security_group_alpha_id, value: '',
-                                                                            description: 'AliCloud Security Group ID.')
-alicloud_security_group_name = input(:alicloud_security_group_name, value: '',
-                                                                    description: 'AliCloud Security Group name.')
-alicloud_security_group_description = input(:alicloud_security_group_description, value: '',
-                                                                                  description: 'AliCloud Security Group name.')
-alicloud_security_group_rule_port_in_range = input(:alicloud_security_group_rule_port_in_range, value: '',
-                                                                                                description: 'a port in AliCloud Security Group ingress rule port range')
-alicloud_security_group_rule_port_not_in_range = input(:alicloud_security_group_rule_port_not_in_range, value: '',
-                                                                                                        description: 'a port not in AliCloud Security Group ingress rule port range')
-alicloud_security_group_rule_cidr = input(:alicloud_security_group_rule_cidr, value: '',
-                                                                              description: 'AliCloud Security Group ingress rule IPv4 range')
-alicloud_security_group_rule_cidr_not_in = input(:alicloud_security_group_rule_cidr_not_in, value: '',
-                                                                                            description: 'a CIDR not in AliCloud Security Group ingress rule IPv4 range')
+alicloud_security_group_alpha_id = input(:alicloud_security_group_alpha_id, value: '', description: 'AliCloud Security Group ID.')
+alicloud_security_group_name = input(:alicloud_security_group_name, value: '', description: 'AliCloud Security Group name.')
+alicloud_security_group_description = input(:alicloud_security_group_description, value: '', description: 'AliCloud Security Group name.')
+alicloud_security_group_rule_port_in_range = input(:alicloud_security_group_rule_port_in_range, value: '', description: 'A port in AliCloud Security Group ingress rule port range.')
+alicloud_security_group_rule_port_not_in_range = input(:alicloud_security_group_rule_port_not_in_range, value: '', description: 'A port not in AliCloud Security Group ingress rule port range.')
+alicloud_security_group_rule_cidr = input(:alicloud_security_group_rule_cidr, value: '', description: 'AliCloud Security Group ingress rule IPv4 range.')
+alicloud_security_group_rule_cidr_not_in = input(:alicloud_security_group_rule_cidr_not_in, value: '', description: 'A CIDR not in AliCloud Security Group ingress rule IPv4 range.')
 
 title 'Test single AliCloud Security Groups'
 

--- a/test/integration/verify/controls/alicloud_security_groups.rb
+++ b/test/integration/verify/controls/alicloud_security_groups.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 title 'Test AliCloud Security Groups in bulk'
 
 control 'alicloud-security-groups-1.0' do

--- a/test/integration/verify/controls/alicloud_slb.rb
+++ b/test/integration/verify/controls/alicloud_slb.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 alicloud_slb_http_id = input(:alicloud_slb_http_id, value: '', description: 'AliCloud slb http ID.')
 alicloud_slb_https_id = input(:alicloud_slb_https_id, value: '', description: 'AliCloud slb https ID.')
 

--- a/test/integration/verify/controls/alicloud_slbs.rb
+++ b/test/integration/verify/controls/alicloud_slbs.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 title 'Test AliCloud Server Load Balancers in bulk'
 
 control 'alicloud-slbs-1.0' do

--- a/test/integration/verify/controls/alicloud_sts_caller_identity.rb
+++ b/test/integration/verify/controls/alicloud_sts_caller_identity.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 title 'Ensure AliCloud credentials being used for the Inspec scan have the correct properties.'
 
 control 'alicloud-sts-caller-identity-1.0' do

--- a/test/integration/verify/controls/alicloud_vpc.rb
+++ b/test/integration/verify/controls/alicloud_vpc.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 title 'Test single AliCloud VPC'
 
 alicloud_vpc_id = input(:alicloud_vpc_id, value: '', description: 'AliCloud VPC ID')

--- a/test/integration/verify/controls/alicloud_vpcs.rb
+++ b/test/integration/verify/controls/alicloud_vpcs.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 title 'Test AliCloud VPC in bulk'
 
 control 'alicloud-vpcs-1.0' do

--- a/test/unit/helper.rb
+++ b/test/unit/helper.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 gem 'mocha'
 
 require 'minitest/autorun'

--- a/test/unit/resources/alicloud_apsaradb_rds_instance_test.rb
+++ b/test/unit/resources/alicloud_apsaradb_rds_instance_test.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require 'helper'
 require 'alicloud_apsaradb_rds_instance'
 

--- a/test/unit/resources/alicloud_apsaradb_rds_instances_test.rb
+++ b/test/unit/resources/alicloud_apsaradb_rds_instances_test.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require 'helper'
 require 'alicloud_apsaradb_rds_instances'
 

--- a/test/unit/resources/alicloud_disk_test.rb
+++ b/test/unit/resources/alicloud_disk_test.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require 'helper'
 require 'alicloud_disk'
 

--- a/test/unit/resources/alicloud_disks_test.rb
+++ b/test/unit/resources/alicloud_disks_test.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require 'helper'
 require 'alicloud_disks'
 

--- a/test/unit/resources/alicloud_ecs_instance_test.rb
+++ b/test/unit/resources/alicloud_ecs_instance_test.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require 'helper'
 require 'alicloud_ecs_instance'
 

--- a/test/unit/resources/alicloud_ecs_instances_test.rb
+++ b/test/unit/resources/alicloud_ecs_instances_test.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require 'helper'
 require 'alicloud_ecs_instances'
 

--- a/test/unit/resources/alicloud_ram_policies_test.rb
+++ b/test/unit/resources/alicloud_ram_policies_test.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require 'helper'
 require 'alicloud_ram_policies'
 

--- a/test/unit/resources/alicloud_ram_policy_test.rb
+++ b/test/unit/resources/alicloud_ram_policy_test.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require 'helper'
 require 'alicloud_ram_policy'
 

--- a/test/unit/resources/alicloud_ram_user_mfa_test.rb
+++ b/test/unit/resources/alicloud_ram_user_mfa_test.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require 'helper'
 require 'alicloud_ram_user_mfa'
 

--- a/test/unit/resources/alicloud_ram_user_test.rb
+++ b/test/unit/resources/alicloud_ram_user_test.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require 'helper'
 require 'alicloud_ram_user'
 

--- a/test/unit/resources/alicloud_ram_users_test.rb
+++ b/test/unit/resources/alicloud_ram_users_test.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require 'helper'
 require 'alicloud_ram_users'
 


### PR DESCRIPTION
### Description

1. We have removed the frozen literal from the code.
2. Changed the attribute to input in the integration tests.

### Issues Resolved

NA

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
