### PR TITLE
Feature/CHEF-2076 create alicloud api client

### DIFF
--- a/libraries/alicloud/api_client.rb
+++ b/libraries/alicloud/api_client.rb
@@ -1,0 +1,77 @@
+require 'set'
+require 'openssl'
+require 'rest-client'
+require 'active_support/all'
+require 'alicloud/helpers/authentication'
+require 'alicloud/helpers/params'
+require 'inspec' unless defined?(::Inspec::VERSION) # tests don't recognise inspec version unless required!
+
+module AliCloud
+  ConnectionError = Class.new(StandardError)
+  class APIClient
+    include Helpers::Authentication
+    include Helpers::Params
+    attr_accessor :endpoint, :api_version, :access_key_id, :access_key_secret, :security_token, :codes, :opts, :verbose,
+                  :http_method
+
+    DEFAULT_UA = "Inspec-Alicloud #{Gem::Platform.local.os} #{Gem::Platform.local.cpu}) Ruby/#{RUBY_VERSION} Core/#{Inspec::VERSION}".freeze
+    DEFAULT_CONTENT_TYPE = 'application/x-www-form-urlencoded'.freeze
+    def initialize(config, verbose: false)
+      validate(config)
+
+      self.endpoint = config[:endpoint]
+      self.api_version = config[:api_version]
+      self.access_key_id = config[:access_key_id]
+      self.access_key_secret = config[:access_key_secret]
+      self.security_token = config[:security_token]
+      self.opts = config[:opts] || {}
+      self.verbose = verbose.instance_of?(TrueClass) && verbose
+      self.codes = Set.new([200, '200', 'OK', 'Success'])
+      codes.merge(config[:codes]) if config[:codes]
+    end
+
+    def request(action:, params: {}, opts: {})
+      opts = self.opts.merge(opts)
+      self.http_method = (opts[:method] || 'GET').upcase
+      querystring = querystring_from(opts, action, params)
+      uri = http_method == 'POST' ? '/' : "/?#{querystring}"
+
+      headers = { 'User-Agent' => DEFAULT_UA }
+      if http_method == 'POST'
+        headers['Content-Type'] = DEFAULT_CONTENT_TYPE
+        body = querystring
+      end
+
+      response = execute_request(http_method, uri, headers, body)
+      JSON.parse(response.body)
+    rescue RestClient::ExceptionWithResponse => e
+      handle_rest_client_exception(e, uri)
+    rescue StandardError => e
+      handle_generic_exception(e)
+    end
+
+    private
+
+    def execute_request(method, uri, headers, body)
+      RestClient::Request.execute(
+        method: method.downcase.to_sym,
+        url: "#{endpoint}#{uri}",
+        headers: headers,
+        payload: body,
+      )
+    end
+
+    def handle_rest_client_exception(exception, uri)
+      response_body = JSON.parse(exception.response.body)
+      if response_body['Code'] && !response_body['Code'].to_s.empty? && !codes.include?(response_body['Code'])
+        raise StandardError, "Code: #{response_body['Code']}, Message: #{response_body['Message']}, URL: #{uri}"
+      end
+
+      response_body
+    end
+
+    def handle_generic_exception(exception)
+      raise AliCloud::ConnectionError, "Failed to execute request: #{exception.message}"
+    end
+  end
+end

--- a/libraries/alicloud/helpers/authentication.rb
+++ b/libraries/alicloud/helpers/authentication.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module AliCloud
+  module Helpers
+    module Authentication
+      private
+
+      def generate_signature(string_to_sign)
+        key = "#{access_key_secret}&"
+        Base64.encode64(OpenSSL::HMAC.digest('sha1', key, string_to_sign)).strip
+      end
+
+      def default_params
+        default_params = {
+          'Format' => 'JSON',
+          'SignatureMethod' => 'HMAC-SHA1',
+          'SignatureNonce' => SecureRandom.hex(16),
+          'SignatureVersion' => '1.0',
+          'Timestamp' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ'),
+          'AccessKeyId' => access_key_id,
+          'Version' => api_version,
+        }
+        default_params.merge!('SecurityToken' => security_token) if security_token
+        default_params
+      end
+    end
+  end
+end

--- a/libraries/alicloud/helpers/params.rb
+++ b/libraries/alicloud/helpers/params.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+module AliCloud
+  module Helpers
+    module Params
+      private
+
+      def querystring_from(opts, action, params)
+        params = prepare_params(opts, action, params)
+        normalized = normalize_params_for(params)
+        canonicalize(normalized)
+      end
+
+      def prepare_params(opts, action, params)
+        action = upcase_first(action) if opts[:format_action]
+        params = format_params(params) unless opts[:format_params]
+        defaults = default_params
+        { Action: action }.merge(defaults).merge(params)
+      end
+
+      def normalize_params_for(params)
+        normalized = normalize(params)
+        string_to_sign = generate_string_to_sign(http_method, normalized)
+        signature = generate_signature(string_to_sign)
+        normalized.push(['Signature', encode(signature)])
+        normalized
+      end
+
+      def add_default_params(params, action)
+        { Action: action }.merge(default_params).merge(params)
+      end
+
+      # Converts just the first character to uppercase.
+      def upcase_first(string)
+        string.camelize
+      end
+
+      def generate_string_to_sign(method, normalized)
+        "#{method}&#{encode('/')}&#{encode(canonicalize(normalized))}"
+      end
+
+      def canonicalize(normalized)
+        normalized.map { |element| "#{element.first}=#{element.last}" }.join('&')
+      end
+
+      def encode(string)
+        encoded = CGI.escape(string.to_s)
+        encoded.gsub(/\+/, '%20')
+      end
+
+      def format_params(param_hash)
+        param_hash.transform_keys { |key| upcase_first(key.to_s).to_sym }
+      end
+
+      # def format_params(param_hash)
+      #   param_hash.transform_keys { |key| upcase_first(key.to_s).to_sym }
+      # end
+
+      def replace_repeat_list(target, key, repeat)
+        repeat.each_with_index do |item, index|
+          if item.instance_of?(Hash)
+            item.each_key { |k| target["#{key}.#{index.next}.#{k}"] = item[k] }
+          else
+            target["#{key}.#{index.next}"] = item
+          end
+        end
+        target
+      end
+
+      def flat_params(params)
+        target = {}
+        params.each do |key, value|
+          if value.instance_of?(Array)
+            replace_repeat_list(target, key, value)
+          else
+            target[key.to_s] = value
+          end
+        end
+        target
+      end
+
+      def normalize(params)
+        flat_params(params)
+          .sort
+          .to_h
+          .map { |key, value| [encode(key), encode(value)] }
+      end
+
+      def validate(config)
+        raise ArgumentError, 'must pass "config"' unless config
+        raise ArgumentError, 'must pass "config[:endpoint]"' unless config[:endpoint]
+        unless config[:endpoint].start_with?('http://') || config[:endpoint].start_with?('https://')
+          raise ArgumentError, '"config.endpoint" must start with \'https://\' or \'http://\'.'
+        end
+        raise ArgumentError, 'must pass "config[:api_version]"' unless config[:api_version]
+        raise ArgumentError, 'must pass "config[:access_key_id]"' unless config[:access_key_id]
+        raise ArgumentError, 'must pass "config[:access_key_secret]"' unless config[:access_key_secret]
+      end
+    end
+  end
+end

--- a/libraries/alicloud_backend.rb
+++ b/libraries/alicloud_backend.rb
@@ -2,6 +2,7 @@ require 'aliyunsdkcore'
 require 'aliyun/oss'
 require 'rspec/expectations'
 require 'alicloud/oss/client'
+require 'alicloud/api_client'
 
 # AliCloud Inspec Backend Classes
 #
@@ -44,12 +45,12 @@ class AliCloudConnection
                  else
                    "https://#{api}.#{region}.aliyuncs.com"
                  end
-    client = RPCClient.new(
-      access_key_id: ENV['ALICLOUD_ACCESS_KEY'],
+    client = AliCloud::APIClient.new(
+      { access_key_id: ENV['ALICLOUD_ACCESS_KEY'],
       access_key_secret: ENV['ALICLOUD_SECRET_KEY'],
       security_token: ENV['ALICLOUD_SECURITY_TOKEN'],
       endpoint: endpoint,
-      api_version: api_version,
+      api_version: api_version },
     )
     AliCloudCommonClient.new(client)
   end


### PR DESCRIPTION
### Description

Please describe what this change achieves. Ensure you have read the [Contributing to InSpec AliCloud](https://github.com/chef-customers/inspec-alicloud/CONTRIBUTING.md) document before submitting.

This change introduces new REST API client which enables connections to Alicloud rather than using outdated SDKs.

It builds and encapsulates tokens and signatures part of the headers and request body as querystring.
uses RESTClient library for HTTP requests

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant
https://chefio.atlassian.net/browse/CHEF-2076

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [X] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [X] All Unit Tests pass
- [X] `rake lint` passes
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
