### PR TITLE
CHEF-27122 - standardize - remove_sla_from_readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # InSpec for AliCloud
 
-* **[Project State](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md): Prototyping**
-
 This InSpec resource pack uses the AliCloud SDK v0.8.0 and provides the required resources to write tests for resources in AliCloud.
 
 ## Prerequisites


### PR DESCRIPTION
This pull request removes the oft-misleading Chef SLA text from the README.md file.

This action is being taken as part of the [2025 Repo Standardization Initiative](https://github.com/chef-boneyard/oss-repo-standardization-2025). 
As Progress Chef makes a best effort to respond to issues and pull requests in a timely manner, and prioritizes bugfixes and security updates on a customer-driven basis (which may span repos, or have no repo footprint at all), we no longer support the concept of a Service Level Agreement (SLA) on a repository-centric basis. For further details, see [Repo SLA Removal FAQ](https://github.com/chef-boneyard/oss-repo-standardization-2025/blob/main/messaging/sla-removal.md).