### PR TITLE
CHEF-31158 Setup common config to block PR merges if trufflehog fails

### DIFF
--- a/.github/workflows/ci-main-pull-request-stub.yml
+++ b/.github/workflows/ci-main-pull-request-stub.yml
@@ -105,6 +105,7 @@ jobs:
       # scc-output-filename: 'scc-output.txt'
       perform-language-linting: true    # Perform language-specific linting and pre-compilation checks
       perform-trufflehog-scan: true
+      fail-trufflehog-on-secrets-found: true
       perform-trivy-scan: true
              
       # perform application build and unit testing, will use custom repository properties when implemented for chef-primary-application, chef-build-profile, and chef-build-language


### PR DESCRIPTION
This PR updates the CI workflow configuration to block PR merges when Trufflehog detects secrets.

- Renamed versioned stub to `ci-main-pull-request-stub.yml`
- Added `fail-trufflehog-on-secrets-found: true` to fail builds when secrets are detected