### PR TITLE
Fix SBOM pipeline: add run-bundle-install to generate Gemfile.lock at runtime

### DIFF
--- a/.github/workflows/ci-main-pull-request-stub.yml
+++ b/.github/workflows/ci-main-pull-request-stub.yml
@@ -170,6 +170,7 @@ jobs:
 
       # perform Blackduck software composition analysis (SCA) for 3rd party CVEs, licensing, and operational risk
       perform-blackduck-sca-scan: true # combined with generate sbom & generate github-sbom, also needs version above
+      run-bundle-install: true # generate Gemfile.lock at runtime for SBOM pipeline
       blackduck-project-group-name: 'Chef-Agents' # typically one of (Chef), Chef-Agents, Chef-Automate, Chef-Chef360, Chef-Habitat, Chef-Infrastructure-Server, Chef-Shared-Services, Chef-Non-Product'
       blackduck-project-name: ${{ github.event.repository.name }} # BlackDuck project name, typically the repository name
       blackduck-force-low-accuracy-mode: false # if true, forces BlackDuck Detect to run in low accuracy mode which can reduce scan time for large projects at the cost of potentially missing some vulnerabilities; see https://synopsys.atlassian.net/wiki/spaces/INTDOCS/pages/1138617921/Black+Duck+Detect+Accuracy+Levels for details


### PR DESCRIPTION
This PR fixes the SBOM/BlackDuck SCA pipeline by adding `run-bundle-install: true` to generate `Gemfile.lock` at runtime, since these repos do not commit a `Gemfile.lock`.

- Renamed versioned stub to `ci-main-pull-request-stub.yml`
- Added `run-bundle-install: true` to generate `Gemfile.lock` at runtime for the SBOM/BlackDuck SCA pipeline